### PR TITLE
Remove redundant theme effect from ThemeProvider

### DIFF
--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -12,21 +12,5 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     document.documentElement.classList.add(theme)
   }, [theme])
 
-  // Also apply theme on initial load to handle SSR
-  useEffect(() => {
-    const storedTheme = localStorage.getItem('theme-storage')
-    if (storedTheme) {
-      try {
-        const parsed = JSON.parse(storedTheme)
-        if (parsed.state?.theme) {
-          document.documentElement.classList.remove('light', 'dark')
-          document.documentElement.classList.add(parsed.state.theme)
-        }
-      } catch (error) {
-        console.error('Error parsing stored theme:', error)
-      }
-    }
-  }, [])
-
   return <>{children}</>
 }


### PR DESCRIPTION
Remove redundant `useEffect` in `ThemeProvider` to eliminate race condition and unsafe `localStorage` access.

---

[Open in Web](https://www.cursor.com/agents?id=bc-681ff2f7-16dd-4f83-b115-83c7dc43fd8e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-681ff2f7-16dd-4f83-b115-83c7dc43fd8e)