### PR TITLE
Add AGENTS.md with development environment instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+**Chronicler's Desk** is a D&D Dungeon Master reference tool built with Next.js 15 (App Router, Turbopack), React 19, Tailwind CSS 4, and shadcn/ui. It uses **Convex** as its serverless backend/database and **Clerk** for authentication.
+
+### Required Environment Variables
+
+Create `.env.local` with:
+
+```
+NEXT_PUBLIC_CONVEX_URL=<your-convex-deployment-url>
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=<your-clerk-publishable-key>
+CLERK_SECRET_KEY=<your-clerk-secret-key>
+```
+
+Without these, the dev server starts but returns 500 on all routes.
+
+### Running the App
+
+| Command | Purpose |
+|---------|---------|
+| `pnpm dev` | Start Next.js dev server with Turbopack on port 3000 |
+| `pnpm lint` | Run ESLint |
+| `pnpm build` | Production build (requires env vars) |
+| `npx convex dev` | Start Convex dev backend (only needed if modifying Convex functions) |
+
+### Key Gotchas
+
+- The app wraps everything in `ClerkProvider` and `ConvexClientProvider` at the root layout level. Every route requires both services to be configured.
+- Clerk middleware (`middleware.ts`) runs on all routes except static assets. The app is inaccessible without valid Clerk keys.
+- `pnpm install` may show warnings about ignored build scripts (`@tailwindcss/oxide`, `sharp`, `unrs-resolver`). These don't block development but may affect production builds with image optimization.
+- The project uses `pnpm@10.14.0` as its package manager (specified in `package.json` `packageManager` field).
+- TypeScript compilation (`npx tsc --noEmit`) passes cleanly and is a good way to verify changes without needing credentials.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific development instructions and updates `.gitignore` for this Next.js + Convex + Clerk application.

## What's included

- `AGENTS.md` with overview of the tech stack, required environment variables, common commands, and key development gotchas
- `.gitignore` entry for `.clerk/` directory (auto-generated by Clerk SDK, prevents accidental secret commits)

## Development Environment Verification

All checks pass with credentials configured:

| Check | Result |
|-------|--------|
| `pnpm install` | 438 packages installed |
| `pnpm lint` | No ESLint warnings or errors |
| `npx tsc --noEmit` | TypeScript compiles cleanly |
| `pnpm dev` | Dev server starts on port 3000 (Turbopack) |
| `pnpm build` | Production build succeeds |
| All routes (`/`, `/references/bestiary`, `/references/spells`, `/references/items`) | HTTP 200 |

## Demo

[chroniclers_desk_app_demo.mp4](https://cursor.com/agents/bc-485266df-4619-4111-9bd9-8a44ccdb8267/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchroniclers_desk_app_demo.mp4)

[App dashboard showing D&D reference sections](https://cursor.com/agents/bc-485266df-4619-4111-9bd9-8a44ccdb8267/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_dashboard.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-485266df-4619-4111-9bd9-8a44ccdb8267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-485266df-4619-4111-9bd9-8a44ccdb8267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

