### PR TITLE
Load bestiary creatures from Open5e

### DIFF
--- a/app/api/open5e/monsters/[slug]/route.ts
+++ b/app/api/open5e/monsters/[slug]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { toOpen5eMonster, type Open5eMonster } from "@/lib/bestiary/open5e";
+
+interface RouteContext {
+  params: Promise<{
+    slug: string;
+  }>;
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  const { slug } = await context.params;
+  const response = await fetch(`https://api.open5e.com/v1/monsters/${encodeURIComponent(slug)}/`, {
+    next: { revalidate: 60 * 60 },
+  });
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { error: "Failed to load Open5e monster." },
+      { status: response.status }
+    );
+  }
+
+  const monster = (await response.json()) as Open5eMonster;
+  return NextResponse.json(toOpen5eMonster(monster));
+}

--- a/app/api/open5e/monsters/route.ts
+++ b/app/api/open5e/monsters/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import {
+  buildOpen5eListUrl,
+  toOpen5eMonsterBase,
+  type Open5eMonsterListItem,
+} from "@/lib/bestiary/open5e";
+
+interface Open5eListResponse {
+  next: string | null;
+  results: Open5eMonsterListItem[];
+}
+
+const MAX_OPEN5E_PAGES = 40;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const search = searchParams.get("search") ?? undefined;
+  const filters = Object.fromEntries(searchParams.entries());
+  delete filters.search;
+
+  const monsters = [];
+  let nextUrl: string | null = buildOpen5eListUrl({ search, filters }).toString();
+  let pageCount = 0;
+
+  while (nextUrl && pageCount < MAX_OPEN5E_PAGES) {
+    const response = await fetch(nextUrl, { next: { revalidate: 60 * 60 } });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: "Failed to load Open5e monsters." },
+        { status: response.status }
+      );
+    }
+
+    const page = (await response.json()) as Open5eListResponse;
+    monsters.push(...page.results.map(toOpen5eMonsterBase));
+    nextUrl = page.next;
+    pageCount += 1;
+  }
+
+  return NextResponse.json({ results: monsters });
+}

--- a/app/providers/ConvexClientProvider.tsx
+++ b/app/providers/ConvexClientProvider.tsx
@@ -1,10 +1,16 @@
 "use client";
 
-import { ConvexProvider, ConvexReactClient } from "convex/react";
+import { useAuth } from "@clerk/nextjs";
+import { ConvexReactClient } from "convex/react";
+import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { ReactNode } from "react";
 
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
-  return <ConvexProvider client={convex}>{children}</ConvexProvider>;
+  return (
+    <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
+      {children}
+    </ConvexProviderWithClerk>
+  );
 }

--- a/app/references/bestiary/data-table.tsx
+++ b/app/references/bestiary/data-table.tsx
@@ -21,7 +21,7 @@ import { LoaderPinwheelIcon } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { api } from "@/convex/_generated/api";
-import { mergeBestiaryRows } from "@/lib/bestiary/open5e";
+import { mergeBestiaryRows, shouldShowBestiaryTableLoading } from "@/lib/bestiary/open5e";
 import { useMemo } from "react";
 import type { MonsterBase } from "./type";
 
@@ -88,8 +88,11 @@ export default function DataTable() {
 
     return mergeBestiaryRows(open5eMonsters.data, customMonsters ?? EMPTY_BESTIARY_ROWS);
   }, [customMonsters, open5eMonsters.data]);
-  const isLoading =
-    open5eMonsters.isPending || !isLoaded || (isSignedIn === true && customMonsters === undefined);
+  const isLoading = shouldShowBestiaryTableLoading({
+    isOpen5ePending: open5eMonsters.isPending,
+    isSignedIn,
+    customRowsLoaded: customMonsters !== undefined,
+  });
 
   // TanStack Table exposes function properties that React Compiler cannot memoize safely.
   // eslint-disable-next-line react-hooks/incompatible-library

--- a/app/references/bestiary/data-table.tsx
+++ b/app/references/bestiary/data-table.tsx
@@ -29,6 +29,8 @@ interface Open5eListResponse {
   results: MonsterBase[];
 }
 
+const EMPTY_BESTIARY_ROWS: MonsterBase[] = [];
+
 async function fetchOpen5eMonsters(search: string | undefined, filters: Record<string, string>) {
   const params = new URLSearchParams();
 
@@ -79,9 +81,13 @@ export default function DataTable() {
         }
       : "skip"
   );
-  const monsters = open5eMonsters.data
-    ? mergeBestiaryRows(open5eMonsters.data, customMonsters ?? [])
-    : [];
+  const monsters = useMemo(() => {
+    if (!open5eMonsters.data) {
+      return EMPTY_BESTIARY_ROWS;
+    }
+
+    return mergeBestiaryRows(open5eMonsters.data, customMonsters ?? EMPTY_BESTIARY_ROWS);
+  }, [customMonsters, open5eMonsters.data]);
   const isLoading =
     open5eMonsters.isPending || !isLoaded || (isSignedIn === true && customMonsters === undefined);
 

--- a/app/references/bestiary/data-table.tsx
+++ b/app/references/bestiary/data-table.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { useUser } from "@clerk/nextjs";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useQuery as useReactQuery } from "@tanstack/react-query";
 import {
   Table,
   TableBody,
@@ -9,34 +15,80 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { useQuery } from "convex/react";
+import { useQuery as useConvexQuery } from "convex/react";
 import { columns } from "./columns";
 import { LoaderPinwheelIcon } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { api } from "@/convex/_generated/api";
+import { mergeBestiaryRows } from "@/lib/bestiary/open5e";
+import { useMemo } from "react";
+import type { MonsterBase } from "./type";
+
+interface Open5eListResponse {
+  results: MonsterBase[];
+}
+
+async function fetchOpen5eMonsters(search: string | undefined, filters: Record<string, string>) {
+  const params = new URLSearchParams();
+
+  if (search) {
+    params.set("search", search);
+  }
+
+  for (const [key, value] of Object.entries(filters)) {
+    params.set(key, value);
+  }
+
+  const response = await fetch(`/api/open5e/monsters?${params.toString()}`);
+
+  if (!response.ok) {
+    throw new Error("Failed to load Open5e monsters.");
+  }
+
+  const data = (await response.json()) as Open5eListResponse;
+  return data.results;
+}
 
 export default function DataTable() {
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { isLoaded, isSignedIn } = useUser();
   const search = searchParams.get("search");
-  const filters: Record<string, string> = {};
-  searchParams.forEach((value, key) => {
-    if (key !== "search" && key !== "monsterId") {
-      filters[key] = value;
-    }
-  });
+  const filters = useMemo(() => {
+    const nextFilters: Record<string, string> = {};
+    searchParams.forEach((value, key) => {
+      if (key !== "search" && key !== "monsterId") {
+        nextFilters[key] = value;
+      }
+    });
+    return nextFilters;
+  }, [searchParams]);
 
-  const monsters = useQuery(api.monsters.get, {
-    search: search ?? undefined,
-    filters,
+  const open5eMonsters = useReactQuery({
+    queryKey: ["open5e-monsters", search, filters],
+    queryFn: () => fetchOpen5eMonsters(search ?? undefined, filters),
   });
+  const customMonsters = useConvexQuery(
+    api.monsters.get,
+    isLoaded && isSignedIn
+      ? {
+          search: search ?? undefined,
+          filters,
+        }
+      : "skip"
+  );
+  const monsters = open5eMonsters.data
+    ? mergeBestiaryRows(open5eMonsters.data, customMonsters ?? [])
+    : [];
+  const isLoading =
+    open5eMonsters.isPending || !isLoaded || (isSignedIn === true && customMonsters === undefined);
 
   // TanStack Table exposes function properties that React Compiler cannot memoize safely.
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
-    data: monsters ?? [],
+    data: monsters,
     columns,
     getCoreRowModel: getCoreRowModel(),
   });
@@ -47,7 +99,7 @@ export default function DataTable() {
     router.replace(`${pathname}?${params.toString()}`);
   };
 
-  return monsters !== undefined ? (
+  return !isLoading ? (
     <div className="h-full flex flex-col">
       <ScrollArea className="h-full w-full rounded-md border">
         <div className="h-full w-full">
@@ -66,7 +118,13 @@ export default function DataTable() {
               ))}
             </TableHeader>
             <TableBody>
-              {table.getRowModel().rows.length ? (
+              {open5eMonsters.isError ? (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-24 text-center">
+                    Unable to load Open5e creatures.
+                  </TableCell>
+                </TableRow>
+              ) : table.getRowModel().rows.length ? (
                 table.getRowModel().rows.map((row) => (
                   <TableRow
                     key={row.id}

--- a/app/references/bestiary/monsterView.tsx
+++ b/app/references/bestiary/monsterView.tsx
@@ -18,18 +18,48 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TabsContent } from "@radix-ui/react-tabs";
 import { cn } from "@/lib/utils";
 import { api } from "@/convex/_generated/api";
-import { useQuery } from "convex/react";
+import { useQuery as useConvexQuery } from "convex/react";
+import { useQuery as useReactQuery } from "@tanstack/react-query";
 import { LoaderPinwheelIcon } from "lucide-react";
+import { getOpen5eSlugFromId, isOpen5eMonsterId } from "@/lib/bestiary/open5e";
+import { useUser } from "@clerk/nextjs";
+import type { Monster } from "./type";
+
+async function fetchOpen5eMonster(monsterId: string) {
+  const slug = getOpen5eSlugFromId(monsterId);
+  const response = await fetch(`/api/open5e/monsters/${encodeURIComponent(slug)}`);
+
+  if (!response.ok) {
+    throw new Error("Failed to load Open5e monster.");
+  }
+
+  return (await response.json()) as Monster;
+}
 
 export default function MonsterView() {
   const params = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const { isLoaded, isSignedIn } = useUser();
   const monsterId = params.get("monsterId");
+  const isOpen5eMonster = monsterId ? isOpen5eMonsterId(monsterId) : false;
 
-  const monster = useQuery(api.monsters.getById, monsterId ? { id: monsterId } : "skip");
+  const open5eMonster = useReactQuery({
+    queryKey: ["open5e-monster", monsterId],
+    queryFn: () => fetchOpen5eMonster(monsterId!),
+    enabled: !!monsterId && isOpen5eMonster,
+  });
+  const customMonster = useConvexQuery(
+    api.monsters.getById,
+    monsterId && !isOpen5eMonster && isLoaded && isSignedIn ? { id: monsterId } : "skip"
+  );
+  const monster = isOpen5eMonster ? open5eMonster.data : customMonster;
 
-  const isLoading = !!monsterId && monster === undefined;
+  const isLoading =
+    !!monsterId &&
+    (isOpen5eMonster
+      ? open5eMonster.isPending
+      : !isLoaded || (isSignedIn === true && customMonster === undefined));
 
   const handleClose = () => {
     const newParams = new URLSearchParams(params);
@@ -42,6 +72,10 @@ export default function MonsterView() {
       {isLoading ? (
         <div className="h-full flex items-center justify-center">
           <LoaderPinwheelIcon className="animate-spin" />
+        </div>
+      ) : open5eMonster.isError ? (
+        <div className="h-full flex items-center justify-center text-muted-foreground">
+          Unable to load selected Open5e creature.
         </div>
       ) : monster ? (
         <Card className="h-full flex flex-col">

--- a/app/references/bestiary/page.tsx
+++ b/app/references/bestiary/page.tsx
@@ -49,14 +49,14 @@ export default function Bestiary() {
         // Two-panel layout when a monster is selected
         <main className="mx-auto px-4 pt-6 h-[calc(100vh-200px)]">
           <ResizablePanelGroup direction="horizontal" className="h-full">
-            <ResizablePanel defaultSize={50} className="flex flex-col min-h-0">
+            <ResizablePanel defaultSize="50%" minSize="25%" className="flex flex-col min-h-0">
               <SearchBox properties={BESTIARY_FILTER_PROPERTIES} />
               <div className="h-full overflow-hidden">
                 <DataTable />
               </div>
             </ResizablePanel>
             <ResizableHandle className="mx-4" withHandle />
-            <ResizablePanel defaultSize={50} className="flex flex-col min-h-0">
+            <ResizablePanel defaultSize="50%" minSize="25%" className="flex flex-col min-h-0">
               <div className="h-full overflow-hidden">
                 <MonsterView />
               </div>

--- a/app/references/bestiary/page.tsx
+++ b/app/references/bestiary/page.tsx
@@ -6,13 +6,11 @@ import DataTable from "./data-table";
 import MonsterView from "./monsterView";
 import { useSearchParams } from "next/navigation";
 import { SearchBox } from "@/components/SearchBox";
-import { useQuery } from "convex/react";
-import { api } from "@/convex/_generated/api";
+import { BESTIARY_FILTER_PROPERTIES } from "@/lib/bestiary/open5e";
 
 export default function Bestiary() {
   const searchParams = useSearchParams();
   const monsterId = searchParams.get("monsterId");
-  const properties = useQuery(api.monsters.getProperties);
 
   const breadcrumbItems = [
     { label: "Home", href: "/" },
@@ -52,7 +50,7 @@ export default function Bestiary() {
         <main className="mx-auto px-4 pt-6 h-[calc(100vh-200px)]">
           <ResizablePanelGroup direction="horizontal" className="h-full">
             <ResizablePanel defaultSize={50} className="flex flex-col min-h-0">
-              <SearchBox properties={properties} />
+              <SearchBox properties={BESTIARY_FILTER_PROPERTIES} />
               <div className="h-full overflow-hidden">
                 <DataTable />
               </div>
@@ -67,7 +65,7 @@ export default function Bestiary() {
         </main>
       ) : (
         <main className="px-4 pt-6 h-[calc(100vh-250px)]">
-          <SearchBox properties={properties} />
+          <SearchBox properties={BESTIARY_FILTER_PROPERTIES} />
           <div className="h-full w-full">
             <DataTable />
           </div>

--- a/app/references/bestiary/page.tsx
+++ b/app/references/bestiary/page.tsx
@@ -1,17 +1,11 @@
 "use client";
 
-import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/components/ui/resizable";
 import { PageHeader } from "@/components/PageHeader";
 import DataTable from "./data-table";
 import MonsterView from "./monsterView";
 import { useSearchParams } from "next/navigation";
 import { SearchBox } from "@/components/SearchBox";
 import { BESTIARY_FILTER_PROPERTIES } from "@/lib/bestiary/open5e";
-
-const SELECTED_BESTIARY_LAYOUT = {
-  "bestiary-list-panel": 50,
-  "bestiary-detail-panel": 50,
-};
 
 export default function Bestiary() {
   const searchParams = useSearchParams();
@@ -52,33 +46,21 @@ export default function Bestiary() {
       />
       {monsterId ? (
         // Two-panel layout when a monster is selected
-        <main className="mx-auto px-4 pt-6 h-[calc(100vh-200px)]">
-          <ResizablePanelGroup
-            id="bestiary-selected-layout"
-            direction="horizontal"
-            defaultLayout={SELECTED_BESTIARY_LAYOUT}
-            className="h-full">
-            <ResizablePanel
-              id="bestiary-list-panel"
-              defaultSize="50%"
-              minSize="25%"
-              className="flex flex-col min-h-0">
+        <main className="px-4 pt-6 h-[calc(100vh-200px)]">
+          <div className="grid h-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] gap-4">
+            <section className="flex flex-col min-h-0">
               <SearchBox properties={BESTIARY_FILTER_PROPERTIES} />
               <div className="h-full overflow-hidden">
                 <DataTable />
               </div>
-            </ResizablePanel>
-            <ResizableHandle className="mx-4" withHandle />
-            <ResizablePanel
-              id="bestiary-detail-panel"
-              defaultSize="50%"
-              minSize="25%"
-              className="flex flex-col min-h-0">
+            </section>
+            <div className="w-px bg-border" aria-hidden="true" />
+            <section className="flex flex-col min-h-0">
               <div className="h-full overflow-hidden">
                 <MonsterView />
               </div>
-            </ResizablePanel>
-          </ResizablePanelGroup>
+            </section>
+          </div>
         </main>
       ) : (
         <main className="px-4 pt-6 h-[calc(100vh-250px)]">

--- a/app/references/bestiary/page.tsx
+++ b/app/references/bestiary/page.tsx
@@ -8,6 +8,11 @@ import { useSearchParams } from "next/navigation";
 import { SearchBox } from "@/components/SearchBox";
 import { BESTIARY_FILTER_PROPERTIES } from "@/lib/bestiary/open5e";
 
+const SELECTED_BESTIARY_LAYOUT = {
+  "bestiary-list-panel": 50,
+  "bestiary-detail-panel": 50,
+};
+
 export default function Bestiary() {
   const searchParams = useSearchParams();
   const monsterId = searchParams.get("monsterId");
@@ -48,15 +53,27 @@ export default function Bestiary() {
       {monsterId ? (
         // Two-panel layout when a monster is selected
         <main className="mx-auto px-4 pt-6 h-[calc(100vh-200px)]">
-          <ResizablePanelGroup direction="horizontal" className="h-full">
-            <ResizablePanel defaultSize="50%" minSize="25%" className="flex flex-col min-h-0">
+          <ResizablePanelGroup
+            id="bestiary-selected-layout"
+            direction="horizontal"
+            defaultLayout={SELECTED_BESTIARY_LAYOUT}
+            className="h-full">
+            <ResizablePanel
+              id="bestiary-list-panel"
+              defaultSize="50%"
+              minSize="25%"
+              className="flex flex-col min-h-0">
               <SearchBox properties={BESTIARY_FILTER_PROPERTIES} />
               <div className="h-full overflow-hidden">
                 <DataTable />
               </div>
             </ResizablePanel>
             <ResizableHandle className="mx-4" withHandle />
-            <ResizablePanel defaultSize="50%" minSize="25%" className="flex flex-col min-h-0">
+            <ResizablePanel
+              id="bestiary-detail-panel"
+              defaultSize="50%"
+              minSize="25%"
+              className="flex flex-col min-h-0">
               <div className="h-full overflow-hidden">
                 <MonsterView />
               </div>

--- a/convex/monsters.ts
+++ b/convex/monsters.ts
@@ -10,6 +10,12 @@ export const get = query({
     filters: v.optional(v.record(v.string(), v.string())),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+
+    if (!identity) {
+      return [];
+    }
+
     let monstersQuery;
 
     if (args.search) {
@@ -22,19 +28,24 @@ export const get = query({
 
     if (args.filters) {
       for (const [key, value] of Object.entries(args.filters)) {
-        monstersQuery = monstersQuery.filter((q) => q.eq(q.field(key as MonsterField), value));
+        monstersQuery = monstersQuery.filter((q) =>
+          q.eq(q.field(key as MonsterField), normalizeFilterValue(key, value))
+        );
       }
     }
 
     const monsters = await monstersQuery.collect();
 
-    return monsters.map((monster) => ({
-      id: monster.id,
-      name: monster.name,
-      type: monster.type,
-      size: monster.size,
-      hitPoints: monster.hitPoints,
-    }));
+    return monsters
+      .filter((monster) => canReadCustomMonster(monster, identity.subject))
+      .map((monster) => ({
+        id: monster.id,
+        name: monster.name,
+        type: monster.type,
+        subtype: monster.subtype,
+        size: monster.size,
+        hitPoints: monster.hitPoints,
+      }));
   },
 });
 
@@ -43,10 +54,21 @@ export const getById = query({
     id: v.string(),
   },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+
+    if (!identity) {
+      return null;
+    }
+
     const monster = await ctx.db
       .query("monsters")
       .filter((q) => q.eq(q.field("id"), args.id))
       .first();
+
+    if (!monster || !canReadCustomMonster(monster, identity.subject)) {
+      return null;
+    }
+
     return monster;
   },
 });
@@ -65,3 +87,16 @@ export const getProperties = query({
     return Array.from(keys);
   },
 });
+
+function canReadCustomMonster(monster: Doc<"monsters">, userId: string) {
+  return monster.isPublic === true || monster.createdByUserId === userId;
+}
+
+function normalizeFilterValue(key: string, value: string) {
+  if (key === "challengeRating" || key === "hitPoints" || key === "xp" || key === "proficiencyBonus") {
+    const parsedValue = Number(value);
+    return Number.isNaN(parsedValue) ? value : parsedValue;
+  }
+
+  return value;
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -262,6 +262,8 @@ export default defineSchema({
     url: v.string(),
     desc: v.optional(v.string()),
     source: v.optional(v.string()),
+    createdByUserId: v.optional(v.string()),
+    isPublic: v.optional(v.boolean()),
     initiative: v.optional(v.number()),
     actions: v.optional(v.array(monsterActionObject)),
     legendaryActions: v.optional(v.array(legendaryActionObject)),
@@ -272,6 +274,8 @@ export default defineSchema({
   })
     .index("by_name", ["name"])
     .index("by_string_id", ["id"])
+    .index("by_created_by_user_id", ["createdByUserId"])
+    .index("by_is_public", ["isPublic"])
     .searchIndex("search_name", {
       searchField: "name",
     })

--- a/lib/bestiary/open5e.test.ts
+++ b/lib/bestiary/open5e.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildOpen5eListUrl,
+  isOpen5eMonsterId,
+  mergeBestiaryRows,
+  toOpen5eMonster,
+  toOpen5eMonsterBase,
+} from "./open5e.ts";
+
+test("maps an Open5e list result to the table row shape with a namespaced id", () => {
+  const row = toOpen5eMonsterBase({
+    slug: "a-mi-kuk",
+    name: "A-mi-kuk",
+    type: "Aberration",
+    subtype: "",
+    size: "Huge",
+    hit_points: 115,
+  });
+
+  assert.deepEqual(row, {
+    id: "open5e:a-mi-kuk",
+    name: "A-mi-kuk",
+    type: "Aberration",
+    size: "Huge",
+    hitPoints: 115,
+  });
+  assert.equal(isOpen5eMonsterId(row.id), true);
+});
+
+test("maps an Open5e detail result to the monster detail shape", () => {
+  const monster = toOpen5eMonster({
+    slug: "owlbear",
+    name: "Owlbear",
+    desc: "A terrible bear-owl hybrid.",
+    size: "Large",
+    type: "Monstrosity",
+    subtype: "",
+    alignment: "unaligned",
+    armor_class: 13,
+    armor_desc: "natural armor",
+    hit_points: 59,
+    hit_dice: "7d10+21",
+    speed: { walk: 40 },
+    strength: 20,
+    dexterity: 12,
+    constitution: 17,
+    intelligence: 3,
+    wisdom: 12,
+    charisma: 7,
+    skills: { perception: 3 },
+    senses: "darkvision 60 ft., passive Perception 13",
+    languages: "--",
+    challenge_rating: "3",
+    cr: 3,
+    actions: [{ name: "Beak", desc: "Melee Weapon Attack." }],
+    reactions: null,
+    legendary_actions: null,
+    special_abilities: null,
+    document__slug: "srd",
+    document__title: "Systems Reference Document",
+  });
+
+  assert.equal(monster.id, "open5e:owlbear");
+  assert.equal(monster.source, "Systems Reference Document");
+  assert.deepEqual(monster.armorClass, [{ type: "natural armor", value: 13 }]);
+  assert.deepEqual(monster.speed, { walk: "40 ft." });
+  assert.deepEqual(monster.stats, {
+    strength: 20,
+    dexterity: 12,
+    constitution: 17,
+    intelligence: 3,
+    wisdom: 12,
+    charisma: 7,
+  });
+  assert.equal(monster.senses.darkvision, "60 ft.");
+  assert.equal(monster.senses.passivePerception, 13);
+  assert.deepEqual(monster.proficiencies, [
+    {
+      value: 3,
+      proficiency: {
+        index: "skill-perception",
+        name: "Skill: Perception",
+        url: "",
+      },
+    },
+  ]);
+});
+
+test("builds Open5e list URLs from supported bestiary search params", () => {
+  const url = buildOpen5eListUrl({
+    search: "owl",
+    filters: {
+      type: "Monstrosity",
+      size: "Large",
+      challengeRating: "3",
+      source: "srd",
+      unsupported: "ignored",
+    },
+  });
+
+  assert.equal(url.searchParams.get("limit"), "100");
+  assert.equal(url.searchParams.get("name__icontains"), "owl");
+  assert.equal(url.searchParams.get("type"), "Monstrosity");
+  assert.equal(url.searchParams.get("size"), "Large");
+  assert.equal(url.searchParams.get("cr"), "3");
+  assert.equal(url.searchParams.get("document__slug"), "srd");
+  assert.equal(url.searchParams.has("unsupported"), false);
+});
+
+test("merges Open5e and Convex table rows in name order without changing ids", () => {
+  const rows = mergeBestiaryRows(
+    [
+      { id: "open5e:zombie", name: "Zombie", type: "Undead", size: "Medium", hitPoints: 22 },
+      { id: "open5e:aboleth", name: "Aboleth", type: "Aberration", size: "Large", hitPoints: 135 },
+    ],
+    [{ id: "custom-1", name: "Clockwork Ant", type: "Construct", size: "Tiny", hitPoints: 4 }]
+  );
+
+  assert.deepEqual(
+    rows.map((row) => row.id),
+    ["open5e:aboleth", "custom-1", "open5e:zombie"]
+  );
+});

--- a/lib/bestiary/open5e.test.ts
+++ b/lib/bestiary/open5e.test.ts
@@ -5,6 +5,7 @@ import {
   buildOpen5eListUrl,
   isOpen5eMonsterId,
   mergeBestiaryRows,
+  shouldShowBestiaryTableLoading,
   toOpen5eMonster,
   toOpen5eMonsterBase,
 } from "./open5e.ts";
@@ -121,5 +122,16 @@ test("merges Open5e and Convex table rows in name order without changing ids", (
   assert.deepEqual(
     rows.map((row) => row.id),
     ["open5e:aboleth", "custom-1", "open5e:zombie"]
+  );
+});
+
+test("does not block signed-out Open5e rows while Clerk is still loading", () => {
+  assert.equal(
+    shouldShowBestiaryTableLoading({
+      isOpen5ePending: false,
+      isSignedIn: undefined,
+      customRowsLoaded: false,
+    }),
+    false
   );
 });

--- a/lib/bestiary/open5e.ts
+++ b/lib/bestiary/open5e.ts
@@ -1,0 +1,388 @@
+export const OPEN5E_MONSTER_ID_PREFIX = "open5e:";
+
+export const BESTIARY_FILTER_PROPERTIES = ["type", "size", "challengeRating", "source"];
+
+interface BestiaryMonsterBase {
+  type: string;
+  subtype?: string;
+  name: string;
+  id: string;
+  size: string;
+  hitPoints: number;
+}
+
+interface BestiaryReference {
+  index: string;
+  name: string;
+  url: string;
+}
+
+interface BestiaryAction {
+  name: string;
+  desc: string;
+  attackBonus?: number;
+}
+
+interface BestiaryMonster extends BestiaryMonsterBase {
+  index: string;
+  alignment: string;
+  armorClass: Array<{ type: string; value: number; desc?: string }>;
+  hitDice: string;
+  hitPointsRoll: string;
+  speed: {
+    walk?: string;
+    swim?: string;
+    fly?: string;
+    burrow?: string;
+    climb?: string;
+    hover?: boolean;
+  };
+  initiative?: number;
+  proficiencies: Array<{ value: number; proficiency: BestiaryReference }>;
+  damageVulnerabilities: string[];
+  damageResistances: string[];
+  damageImmunities: string[];
+  conditionImmunities: BestiaryReference[];
+  senses: {
+    darkvision?: string;
+    passivePerception: number;
+    blindsight?: string;
+    truesight?: string;
+    tremorsense?: string;
+  };
+  languages: string;
+  challengeRating: number;
+  proficiencyBonus: number;
+  xp: number;
+  specialAbilities?: BestiaryAction[];
+  actions?: BestiaryAction[];
+  legendaryActions?: BestiaryAction[];
+  image?: string;
+  url: string;
+  stats: {
+    strength: number;
+    dexterity: number;
+    constitution: number;
+    intelligence: number;
+    wisdom: number;
+    charisma: number;
+  };
+  desc?: string;
+  reactions?: BestiaryAction[];
+  source?: string;
+}
+
+type BestiarySpeedKey = Exclude<keyof BestiaryMonster["speed"], "hover">;
+
+export interface Open5eMonsterListItem {
+  slug: string;
+  name: string;
+  type: string;
+  subtype?: string | null;
+  size: string;
+  hit_points: number;
+}
+
+export interface Open5eMonster extends Open5eMonsterListItem {
+  desc: string;
+  alignment: string;
+  armor_class: number;
+  armor_desc?: string | null;
+  hit_dice: string;
+  speed: Record<string, number | boolean | string | null | undefined>;
+  strength: number;
+  dexterity: number;
+  constitution: number;
+  intelligence: number;
+  wisdom: number;
+  charisma: number;
+  skills?: Record<string, number | null> | null;
+  damage_vulnerabilities?: string;
+  damage_resistances?: string;
+  damage_immunities?: string;
+  condition_immunities?: string;
+  senses?: string;
+  languages?: string;
+  challenge_rating: string;
+  cr: number;
+  actions?: Open5eAction[] | null;
+  reactions?: Open5eAction[] | null;
+  legendary_actions?: Open5eAction[] | null;
+  special_abilities?: Open5eAction[] | null;
+  img_main?: string | null;
+  document__slug: string;
+  document__title: string;
+}
+
+interface Open5eAction {
+  name: string;
+  desc: string;
+  attack_bonus?: number;
+}
+
+interface BuildOpen5eListUrlArgs {
+  search?: string;
+  filters?: Record<string, string>;
+  offset?: number;
+}
+
+const CHALLENGE_RATING_XP = new Map<number, number>([
+  [0, 10],
+  [0.125, 25],
+  [0.25, 50],
+  [0.5, 100],
+  [1, 200],
+  [2, 450],
+  [3, 700],
+  [4, 1100],
+  [5, 1800],
+  [6, 2300],
+  [7, 2900],
+  [8, 3900],
+  [9, 5000],
+  [10, 5900],
+  [11, 7200],
+  [12, 8400],
+  [13, 10000],
+  [14, 11500],
+  [15, 13000],
+  [16, 15000],
+  [17, 18000],
+  [18, 20000],
+  [19, 22000],
+  [20, 25000],
+  [21, 33000],
+  [22, 41000],
+  [23, 50000],
+  [24, 62000],
+  [25, 75000],
+  [26, 90000],
+  [27, 105000],
+  [28, 120000],
+  [29, 135000],
+  [30, 155000],
+]);
+
+const BESTIARY_SPEED_KEYS = new Set<string>(["walk", "swim", "fly", "burrow", "climb"]);
+
+export function isOpen5eMonsterId(id: string) {
+  return id.startsWith(OPEN5E_MONSTER_ID_PREFIX);
+}
+
+export function getOpen5eSlugFromId(id: string) {
+  return isOpen5eMonsterId(id) ? id.slice(OPEN5E_MONSTER_ID_PREFIX.length) : id;
+}
+
+export function toOpen5eMonsterId(slug: string) {
+  return `${OPEN5E_MONSTER_ID_PREFIX}${slug}`;
+}
+
+export function toOpen5eMonsterBase(monster: Open5eMonsterListItem): BestiaryMonsterBase {
+  const subtype = normalizeOptionalString(monster.subtype);
+  return {
+    id: toOpen5eMonsterId(monster.slug),
+    name: monster.name,
+    type: monster.type,
+    ...(subtype ? { subtype } : {}),
+    size: monster.size,
+    hitPoints: monster.hit_points,
+  };
+}
+
+export function toOpen5eMonster(monster: Open5eMonster): BestiaryMonster {
+  const challengeRating = Number(monster.cr);
+
+  return {
+    ...toOpen5eMonsterBase(monster),
+    index: monster.slug,
+    alignment: monster.alignment,
+    armorClass: [
+      {
+        type: normalizeOptionalString(monster.armor_desc) ?? "armor",
+        value: monster.armor_class,
+      },
+    ],
+    hitDice: monster.hit_dice,
+    hitPointsRoll: monster.hit_dice,
+    speed: mapSpeed(monster.speed),
+    proficiencies: mapSkillProficiencies(monster.skills),
+    damageVulnerabilities: splitList(monster.damage_vulnerabilities),
+    damageResistances: splitList(monster.damage_resistances),
+    damageImmunities: splitList(monster.damage_immunities),
+    conditionImmunities: splitList(monster.condition_immunities).map(toReference),
+    senses: mapSenses(monster.senses),
+    languages: monster.languages || "--",
+    challengeRating,
+    proficiencyBonus: calculateProficiencyBonus(challengeRating),
+    xp: CHALLENGE_RATING_XP.get(challengeRating) ?? 0,
+    specialAbilities: mapActions(monster.special_abilities),
+    actions: mapActions(monster.actions),
+    legendaryActions: mapActions(monster.legendary_actions),
+    image: normalizeOptionalString(monster.img_main),
+    url: `https://api.open5e.com/v1/monsters/${monster.slug}/`,
+    stats: {
+      strength: monster.strength,
+      dexterity: monster.dexterity,
+      constitution: monster.constitution,
+      intelligence: monster.intelligence,
+      wisdom: monster.wisdom,
+      charisma: monster.charisma,
+    },
+    desc: normalizeOptionalString(monster.desc),
+    reactions: mapActions(monster.reactions),
+    source: monster.document__title || monster.document__slug,
+  };
+}
+
+export function buildOpen5eListUrl({ search, filters, offset }: BuildOpen5eListUrlArgs) {
+  const url = new URL("https://api.open5e.com/v1/monsters/");
+  url.searchParams.set("limit", "100");
+  url.searchParams.set("ordering", "name");
+
+  if (offset && offset > 0) {
+    url.searchParams.set("offset", String(offset));
+  }
+
+  if (search) {
+    url.searchParams.set("name__icontains", search);
+  }
+
+  for (const [key, value] of Object.entries(filters ?? {})) {
+    if (!value) {
+      continue;
+    }
+
+    if (key === "type" || key === "size") {
+      url.searchParams.set(key, value);
+    }
+
+    if (key === "challengeRating") {
+      url.searchParams.set("cr", value);
+    }
+
+    if (key === "source") {
+      url.searchParams.set("document__slug", value);
+    }
+  }
+
+  return url;
+}
+
+export function mergeBestiaryRows(
+  open5eRows: BestiaryMonsterBase[],
+  convexRows: BestiaryMonsterBase[]
+) {
+  return [...open5eRows, ...convexRows].sort((left, right) =>
+    left.name.localeCompare(right.name, undefined, { sensitivity: "base" })
+  );
+}
+
+function normalizeOptionalString(value?: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function mapSpeed(speed: Open5eMonster["speed"]): BestiaryMonster["speed"] {
+  const mappedSpeed: BestiaryMonster["speed"] = {};
+
+  for (const [key, value] of Object.entries(speed)) {
+    if (key === "hover") {
+      mappedSpeed.hover = Boolean(value);
+      continue;
+    }
+
+    if (typeof value === "number") {
+      setMappedSpeed(mappedSpeed, key, `${value} ft.`);
+      continue;
+    }
+
+    if (typeof value === "string" && value.trim()) {
+      setMappedSpeed(mappedSpeed, key, value);
+    }
+  }
+
+  return mappedSpeed;
+}
+
+function setMappedSpeed(speed: BestiaryMonster["speed"], key: string, value: string) {
+  if (isBestiarySpeedKey(key)) {
+    speed[key] = value;
+  }
+}
+
+function isBestiarySpeedKey(key: string): key is BestiarySpeedKey {
+  return BESTIARY_SPEED_KEYS.has(key);
+}
+
+function mapSkillProficiencies(skills?: Record<string, number | null> | null) {
+  return Object.entries(skills ?? {})
+    .filter(([, value]) => typeof value === "number")
+    .map(([name, value]) => {
+      const displayName = name
+        .split("_")
+        .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+        .join(" ");
+
+      return {
+        value: value ?? 0,
+        proficiency: {
+          index: `skill-${name.replaceAll("_", "-")}`,
+          name: `Skill: ${displayName}`,
+          url: "",
+        },
+      };
+    });
+}
+
+function splitList(value?: string) {
+  return (value ?? "")
+    .split(/[,;]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function toReference(name: string): BestiaryReference {
+  return {
+    index: name.toLowerCase().replaceAll(/\s+/g, "-"),
+    name,
+    url: "",
+  };
+}
+
+function mapSenses(senses?: string): BestiaryMonster["senses"] {
+  return {
+    darkvision: matchSense(senses, "darkvision"),
+    blindsight: matchSense(senses, "blindsight"),
+    truesight: matchSense(senses, "truesight"),
+    tremorsense: matchSense(senses, "tremorsense"),
+    passivePerception: Number(senses?.match(/passive Perception\s+(\d+)/i)?.[1] ?? 10),
+  };
+}
+
+function matchSense(senses: string | undefined, senseName: string) {
+  return normalizeOptionalString(senses?.match(new RegExp(`${senseName}\\s+([^,]+)`, "i"))?.[1]);
+}
+
+function mapActions(actions?: Open5eAction[] | null): BestiaryAction[] | undefined {
+  if (!actions?.length) {
+    return undefined;
+  }
+
+  return actions.map((action) => ({
+    name: action.name,
+    desc: action.desc,
+    attackBonus: action.attack_bonus,
+  }));
+}
+
+function calculateProficiencyBonus(challengeRating: number) {
+  if (challengeRating <= 4) {
+    return 2;
+  }
+
+  return Math.ceil(challengeRating / 4) + 1;
+}

--- a/lib/bestiary/open5e.ts
+++ b/lib/bestiary/open5e.ts
@@ -126,6 +126,12 @@ interface BuildOpen5eListUrlArgs {
   offset?: number;
 }
 
+interface BestiaryTableLoadingState {
+  isOpen5ePending: boolean;
+  isSignedIn: boolean | undefined;
+  customRowsLoaded: boolean;
+}
+
 const CHALLENGE_RATING_XP = new Map<number, number>([
   [0, 10],
   [0.125, 25],
@@ -275,6 +281,14 @@ export function mergeBestiaryRows(
   return [...open5eRows, ...convexRows].sort((left, right) =>
     left.name.localeCompare(right.name, undefined, { sensitivity: "base" })
   );
+}
+
+export function shouldShowBestiaryTableLoading({
+  isOpen5ePending,
+  isSignedIn,
+  customRowsLoaded,
+}: BestiaryTableLoadingState) {
+  return isOpen5ePending || (isSignedIn === true && !customRowsLoaded);
 }
 
 function normalizeOptionalString(value?: string | null) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Open5e API proxy routes and mapping helpers for bestiary list/detail data.
- Merge Open5e creatures with signed-in users' readable Convex creatures.
- Wire Convex to Clerk auth and restrict custom creature reads to public or owned records.
- Replace the selected bestiary resizable split with a stable two-column layout after browser testing exposed zero-width panel initialization.

## Walkthrough
[bestiary_open5e_owlbear_detail.mp4](https://cursor.com/agents/bc-1ce98a06-0e51-4835-aadd-8d451ae6f6ee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbestiary_open5e_owlbear_detail.mp4)

## Testing
- `node --test --experimental-strip-types lib/bestiary/open5e.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `curl -sS http://localhost:3000/api/open5e/monsters?search=owlbear | python3 -m json.tool | sed -n '1,40p'`
- `curl -sS http://localhost:3000/api/open5e/monsters/owlbear | python3 -m json.tool | sed -n '1,80p'`
- Manual browser walkthrough: signed-out bestiary search for `owlbear`, row selection, and Open5e stat block detail rendering.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ce98a06-0e51-4835-aadd-8d451ae6f6ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ce98a06-0e51-4835-aadd-8d451ae6f6ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

