### PR TITLE
Add Open5e spell reference support

### DIFF
--- a/app/api/open5e/spells/[slug]/route.ts
+++ b/app/api/open5e/spells/[slug]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { toOpen5eSpell, type Open5eSpell } from "@/lib/spells/open5e";
+
+interface RouteContext {
+  params: Promise<{
+    slug: string;
+  }>;
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  const { slug } = await context.params;
+  const response = await fetch(`https://api.open5e.com/v1/spells/${encodeURIComponent(slug)}/`, {
+    next: { revalidate: 60 * 60 },
+  });
+
+  if (!response.ok) {
+    return NextResponse.json({ error: "Failed to load Open5e spell." }, { status: response.status });
+  }
+
+  const spell = (await response.json()) as Open5eSpell;
+  return NextResponse.json(toOpen5eSpell(spell));
+}

--- a/app/api/open5e/spells/route.ts
+++ b/app/api/open5e/spells/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import {
+  buildOpen5eSpellListUrl,
+  toOpen5eSpellBase,
+  type Open5eSpellListItem,
+} from "@/lib/spells/open5e";
+
+interface Open5eSpellListResponse {
+  next: string | null;
+  results: Open5eSpellListItem[];
+}
+
+const MAX_OPEN5E_PAGES = 40;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const search = searchParams.get("search") ?? undefined;
+  const filters = Object.fromEntries(searchParams.entries());
+  delete filters.search;
+
+  const spells = [];
+  let nextUrl: string | null = buildOpen5eSpellListUrl({ search, filters }).toString();
+  let pageCount = 0;
+
+  while (nextUrl && pageCount < MAX_OPEN5E_PAGES) {
+    const response = await fetch(nextUrl, { next: { revalidate: 60 * 60 } });
+
+    if (!response.ok) {
+      return NextResponse.json({ error: "Failed to load Open5e spells." }, { status: response.status });
+    }
+
+    const page = (await response.json()) as Open5eSpellListResponse;
+    spells.push(...page.results.map(toOpen5eSpellBase));
+    nextUrl = page.next;
+    pageCount += 1;
+  }
+
+  return NextResponse.json({ results: spells });
+}

--- a/app/references/spells/columns.tsx
+++ b/app/references/spells/columns.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { SpellBase } from "./type";
+
+export const columns: ColumnDef<SpellBase>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "level",
+    header: "Level",
+    cell: ({ row }) => (row.original.level === 0 ? "Cantrip" : row.original.level),
+  },
+  {
+    accessorKey: "school",
+    header: "School",
+  },
+  {
+    accessorKey: "castingTime",
+    header: "Casting Time",
+  },
+  {
+    accessorKey: "range",
+    header: "Range",
+  },
+  {
+    accessorKey: "classes",
+    header: "Classes",
+    cell: ({ row }) => row.original.classes.join(", "),
+  },
+];

--- a/app/references/spells/data-table.tsx
+++ b/app/references/spells/data-table.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useUser } from "@clerk/nextjs";
+import { useQuery as useReactQuery } from "@tanstack/react-query";
+import { flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { LoaderPinwheelIcon } from "lucide-react";
+import { useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { mergeSpellRows, shouldShowSpellTableLoading } from "@/lib/spells/open5e";
+import { columns } from "./columns";
+import type { SpellBase } from "./type";
+
+interface Open5eSpellListResponse {
+  results: SpellBase[];
+}
+
+const EMPTY_SPELL_ROWS: SpellBase[] = [];
+
+async function fetchOpen5eSpells(search: string | undefined, filters: Record<string, string>) {
+  const params = new URLSearchParams();
+
+  if (search) {
+    params.set("search", search);
+  }
+
+  for (const [key, value] of Object.entries(filters)) {
+    params.set(key, value);
+  }
+
+  const response = await fetch(`/api/open5e/spells?${params.toString()}`);
+
+  if (!response.ok) {
+    throw new Error("Failed to load Open5e spells.");
+  }
+
+  const data = (await response.json()) as Open5eSpellListResponse;
+  return data.results;
+}
+
+export default function DataTable() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isSignedIn } = useUser();
+  const search = searchParams.get("search");
+  const filters = useMemo(() => {
+    const nextFilters: Record<string, string> = {};
+    searchParams.forEach((value, key) => {
+      if (key !== "search" && key !== "spellId") {
+        nextFilters[key] = value;
+      }
+    });
+    return nextFilters;
+  }, [searchParams]);
+
+  const open5eSpells = useReactQuery({
+    queryKey: ["open5e-spells", search, filters],
+    queryFn: () => fetchOpen5eSpells(search ?? undefined, filters),
+  });
+  const spells = useMemo(() => {
+    if (!open5eSpells.data) {
+      return EMPTY_SPELL_ROWS;
+    }
+
+    return mergeSpellRows(open5eSpells.data, EMPTY_SPELL_ROWS);
+  }, [open5eSpells.data]);
+  const isLoading = shouldShowSpellTableLoading({
+    isOpen5ePending: open5eSpells.isPending,
+    isSignedIn,
+    customRowsLoaded: true,
+  });
+
+  // TanStack Table exposes function properties that React Compiler cannot memoize safely.
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data: spells,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const handleRowClick = (spellId: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("spellId", spellId);
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
+  return !isLoading ? (
+    <div className="h-full flex flex-col">
+      <ScrollArea className="h-full w-full rounded-md border">
+        <div className="h-full w-full">
+          <Table>
+            <TableHeader className="sticky top-0 bg-background z-10">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {open5eSpells.isError ? (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-24 text-center">
+                    Unable to load Open5e spells.
+                  </TableCell>
+                </TableRow>
+              ) : table.getRowModel().rows.length ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className="cursor-pointer"
+                    data-state={row.getIsSelected() ? "selected" : ""}
+                    onClick={() => handleRowClick(row.original.id)}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-24 text-center">
+                    No results.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </ScrollArea>
+    </div>
+  ) : (
+    <div className="h-full flex items-center justify-center">
+      <LoaderPinwheelIcon className="animate-spin" />
+    </div>
+  );
+}

--- a/app/references/spells/page.tsx
+++ b/app/references/spells/page.tsx
@@ -1,18 +1,40 @@
+"use client";
+
 import { PageHeader } from "@/components/PageHeader";
+import { SearchBox } from "@/components/SearchBox";
+import { SPELL_FILTER_PROPERTIES } from "@/lib/spells/open5e";
+import { useSearchParams } from "next/navigation";
+import DataTable from "./data-table";
+import SpellView from "./spellView";
 
 export default function Spells() {
+  const searchParams = useSearchParams();
+  const spellId = searchParams.get("spellId");
+
   const breadcrumbItems = [
     { label: "Home", href: "/" },
-    { 
-      label: "References", 
+    {
+      label: "References",
       href: "/references",
       dropdownOptions: [
-        { label: "Bestiary", href: "/references/bestiary", description: "Browse monsters and creatures" },
-        { label: "Spells", href: "/references/spells", description: "Search magical spells and abilities" },
-        { label: "Items", href: "/references/items", description: "Discover magical items and equipment" }
-      ]
+        {
+          label: "Bestiary",
+          href: "/references/bestiary",
+          description: "Browse monsters and creatures",
+        },
+        {
+          label: "Spells",
+          href: "/references/spells",
+          description: "Search magical spells and abilities",
+        },
+        {
+          label: "Items",
+          href: "/references/items",
+          description: "Discover magical items and equipment",
+        },
+      ],
     },
-    { label: "Spells", isCurrentPage: true }
+    { label: "Spells", isCurrentPage: true },
   ];
 
   return (
@@ -22,12 +44,31 @@ export default function Spells() {
         description="Search and browse magical spells and abilities"
         breadcrumbItems={breadcrumbItems}
       />
-
-      <main className="container mx-auto px-4 py-8">
-        <div className="text-center">
-          <p className="text-muted-foreground">Spells reference content coming soon...</p>
-        </div>
-      </main>
+      {spellId ? (
+        <main className="px-4 pt-6 h-[calc(100vh-200px)]">
+          <div className="grid h-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] gap-4">
+            <section className="flex flex-col min-h-0">
+              <SearchBox properties={SPELL_FILTER_PROPERTIES} selectedParamName="spellId" />
+              <div className="h-full overflow-hidden">
+                <DataTable />
+              </div>
+            </section>
+            <div className="w-px bg-border" aria-hidden="true" />
+            <section className="flex flex-col min-h-0">
+              <div className="h-full overflow-hidden">
+                <SpellView />
+              </div>
+            </section>
+          </div>
+        </main>
+      ) : (
+        <main className="px-4 pt-6 h-[calc(100vh-250px)]">
+          <SearchBox properties={SPELL_FILTER_PROPERTIES} selectedParamName="spellId" />
+          <div className="h-full w-full">
+            <DataTable />
+          </div>
+        </main>
+      )}
     </div>
   );
 }

--- a/app/references/spells/page.tsx
+++ b/app/references/spells/page.tsx
@@ -1,74 +1,10 @@
-"use client";
+import { Suspense } from "react";
+import SpellsClient from "./spellsClient";
 
-import { PageHeader } from "@/components/PageHeader";
-import { SearchBox } from "@/components/SearchBox";
-import { SPELL_FILTER_PROPERTIES } from "@/lib/spells/open5e";
-import { useSearchParams } from "next/navigation";
-import DataTable from "./data-table";
-import SpellView from "./spellView";
-
-export default function Spells() {
-  const searchParams = useSearchParams();
-  const spellId = searchParams.get("spellId");
-
-  const breadcrumbItems = [
-    { label: "Home", href: "/" },
-    {
-      label: "References",
-      href: "/references",
-      dropdownOptions: [
-        {
-          label: "Bestiary",
-          href: "/references/bestiary",
-          description: "Browse monsters and creatures",
-        },
-        {
-          label: "Spells",
-          href: "/references/spells",
-          description: "Search magical spells and abilities",
-        },
-        {
-          label: "Items",
-          href: "/references/items",
-          description: "Discover magical items and equipment",
-        },
-      ],
-    },
-    { label: "Spells", isCurrentPage: true },
-  ];
-
+export default function SpellsPage() {
   return (
-    <div className="min-h-screen bg-background">
-      <PageHeader
-        title="Spells"
-        description="Search and browse magical spells and abilities"
-        breadcrumbItems={breadcrumbItems}
-      />
-      {spellId ? (
-        <main className="px-4 pt-6 h-[calc(100vh-200px)]">
-          <div className="grid h-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] gap-4">
-            <section className="flex flex-col min-h-0">
-              <SearchBox properties={SPELL_FILTER_PROPERTIES} selectedParamName="spellId" />
-              <div className="h-full overflow-hidden">
-                <DataTable />
-              </div>
-            </section>
-            <div className="w-px bg-border" aria-hidden="true" />
-            <section className="flex flex-col min-h-0">
-              <div className="h-full overflow-hidden">
-                <SpellView />
-              </div>
-            </section>
-          </div>
-        </main>
-      ) : (
-        <main className="px-4 pt-6 h-[calc(100vh-250px)]">
-          <SearchBox properties={SPELL_FILTER_PROPERTIES} selectedParamName="spellId" />
-          <div className="h-full w-full">
-            <DataTable />
-          </div>
-        </main>
-      )}
-    </div>
+    <Suspense fallback={<div className="min-h-screen bg-background" />}>
+      <SpellsClient />
+    </Suspense>
   );
 }

--- a/app/references/spells/spellView.tsx
+++ b/app/references/spells/spellView.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useQuery as useReactQuery } from "@tanstack/react-query";
+import { LoaderPinwheelIcon, X } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { getOpen5eSpellSlugFromId } from "@/lib/spells/open5e";
+import type { Spell } from "./type";
+
+async function fetchOpen5eSpell(spellId: string) {
+  const slug = getOpen5eSpellSlugFromId(spellId);
+  const response = await fetch(`/api/open5e/spells/${encodeURIComponent(slug)}`);
+
+  if (!response.ok) {
+    throw new Error("Failed to load Open5e spell.");
+  }
+
+  return (await response.json()) as Spell;
+}
+
+export default function SpellView() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const spellId = params.get("spellId");
+
+  const open5eSpell = useReactQuery({
+    queryKey: ["open5e-spell", spellId],
+    queryFn: () => fetchOpen5eSpell(spellId!),
+    enabled: !!spellId,
+  });
+
+  const handleClose = () => {
+    const newParams = new URLSearchParams(params);
+    newParams.delete("spellId");
+    router.push(`${pathname}?${newParams.toString()}`);
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      {open5eSpell.isPending ? (
+        <div className="h-full flex items-center justify-center">
+          <LoaderPinwheelIcon className="animate-spin" />
+        </div>
+      ) : open5eSpell.isError ? (
+        <div className="h-full flex items-center justify-center text-muted-foreground">
+          Unable to load selected Open5e spell.
+        </div>
+      ) : open5eSpell.data ? (
+        <Card className="h-full flex flex-col">
+          <CardHeader className="flex-shrink-0">
+            <div className="flex justify-between items-center scroll-m-20 border-b pb-2">
+              <div>
+                <CardTitle className="text-3xl font-semibold tracking-tight first:mt-0">
+                  {open5eSpell.data.name}
+                </CardTitle>
+                <p className="text-muted-foreground">
+                  {formatSpellLevel(open5eSpell.data.level, open5eSpell.data.school)}
+                </p>
+              </div>
+              <Button variant="ghost" size="icon" onClick={handleClose}>
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="flex-1 min-h-0">
+            <ScrollArea className="h-full">
+              <div className="flex flex-col gap-4">
+                <section className="grid gap-2">
+                  <p className="leading-7">
+                    <b>Casting Time:</b> {open5eSpell.data.castingTime}
+                  </p>
+                  <p className="leading-7">
+                    <b>Range:</b> {open5eSpell.data.range}
+                  </p>
+                  <p className="leading-7">
+                    <b>Components:</b> {open5eSpell.data.components.join(", ")}
+                    {open5eSpell.data.material ? ` (${open5eSpell.data.material})` : null}
+                  </p>
+                  <p className="leading-7">
+                    <b>Duration:</b>{" "}
+                    {open5eSpell.data.requiresConcentration ? "Concentration, " : null}
+                    {open5eSpell.data.duration}
+                  </p>
+                  <p className="leading-7">
+                    <b>Classes:</b> {open5eSpell.data.classes.join(", ") || "--"}
+                  </p>
+                  {open5eSpell.data.canBeCastAsRitual ? (
+                    <p className="leading-7">
+                      <b>Ritual:</b> Yes
+                    </p>
+                  ) : null}
+                </section>
+                <section>
+                  <p className="leading-7 whitespace-pre-line">{open5eSpell.data.desc}</p>
+                </section>
+                {open5eSpell.data.higherLevel ? (
+                  <section>
+                    <h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">
+                      At Higher Levels
+                    </h3>
+                    <p className="leading-7">{open5eSpell.data.higherLevel}</p>
+                  </section>
+                ) : null}
+                {open5eSpell.data.archetype || open5eSpell.data.circles ? (
+                  <section>
+                    {open5eSpell.data.archetype ? (
+                      <p className="leading-7">
+                        <b>Archetype:</b> {open5eSpell.data.archetype}
+                      </p>
+                    ) : null}
+                    {open5eSpell.data.circles ? (
+                      <p className="leading-7">
+                        <b>Circles:</b> {open5eSpell.data.circles}
+                      </p>
+                    ) : null}
+                  </section>
+                ) : null}
+                <div className="flex flex-row-reverse">
+                  <p className="leading-7 text-gray-500">
+                    Source: {open5eSpell.data.source}
+                    {open5eSpell.data.page ? ` (${open5eSpell.data.page})` : null}
+                  </p>
+                </div>
+              </div>
+            </ScrollArea>
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+}
+
+function formatSpellLevel(level: number, school: string) {
+  if (level === 0) {
+    return `${school} cantrip`;
+  }
+
+  return `Level ${level} ${school}`;
+}

--- a/app/references/spells/spellsClient.tsx
+++ b/app/references/spells/spellsClient.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { PageHeader } from "@/components/PageHeader";
+import { SearchBox } from "@/components/SearchBox";
+import { SPELL_FILTER_PROPERTIES } from "@/lib/spells/open5e";
+import { useSearchParams } from "next/navigation";
+import DataTable from "./data-table";
+import SpellView from "./spellView";
+
+export default function SpellsClient() {
+  const searchParams = useSearchParams();
+  const spellId = searchParams.get("spellId");
+
+  const breadcrumbItems = [
+    { label: "Home", href: "/" },
+    {
+      label: "References",
+      href: "/references",
+      dropdownOptions: [
+        {
+          label: "Bestiary",
+          href: "/references/bestiary",
+          description: "Browse monsters and creatures",
+        },
+        {
+          label: "Spells",
+          href: "/references/spells",
+          description: "Search magical spells and abilities",
+        },
+        {
+          label: "Items",
+          href: "/references/items",
+          description: "Discover magical items and equipment",
+        },
+      ],
+    },
+    { label: "Spells", isCurrentPage: true },
+  ];
+
+  return (
+    <div className="min-h-screen bg-background">
+      <PageHeader
+        title="Spells"
+        description="Search and browse magical spells and abilities"
+        breadcrumbItems={breadcrumbItems}
+      />
+      {spellId ? (
+        <main className="px-4 pt-6 h-[calc(100vh-200px)]">
+          <div className="grid h-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] gap-4">
+            <section className="flex flex-col min-h-0">
+              <SearchBox properties={SPELL_FILTER_PROPERTIES} selectedParamName="spellId" />
+              <div className="h-full overflow-hidden">
+                <DataTable />
+              </div>
+            </section>
+            <div className="w-px bg-border" aria-hidden="true" />
+            <section className="flex flex-col min-h-0">
+              <div className="h-full overflow-hidden">
+                <SpellView />
+              </div>
+            </section>
+          </div>
+        </main>
+      ) : (
+        <main className="px-4 pt-6 h-[calc(100vh-250px)]">
+          <SearchBox properties={SPELL_FILTER_PROPERTIES} selectedParamName="spellId" />
+          <div className="h-full w-full">
+            <DataTable />
+          </div>
+        </main>
+      )}
+    </div>
+  );
+}

--- a/app/references/spells/type.ts
+++ b/app/references/spells/type.ts
@@ -1,0 +1,26 @@
+export interface SpellBase {
+  id: string;
+  name: string;
+  level: number;
+  school: string;
+  castingTime: string;
+  range: string;
+  classes: string[];
+  source: string;
+}
+
+export interface Spell extends SpellBase {
+  index: string;
+  desc: string;
+  higherLevel?: string;
+  page?: string;
+  components: string[];
+  material?: string;
+  canBeCastAsRitual: boolean;
+  duration: string;
+  requiresConcentration: boolean;
+  levelLabel: string;
+  archetype?: string;
+  circles?: string;
+  url: string;
+}

--- a/components/SearchBox/index.tsx
+++ b/components/SearchBox/index.tsx
@@ -7,9 +7,10 @@ import { FilterBadge } from "./components/FilterBadge";
 
 interface Props {
   properties?: string[];
+  selectedParamName?: string;
 }
 
-export const SearchBox = ({ properties }: Props) => {
+export const SearchBox = ({ properties, selectedParamName = "monsterId" }: Props) => {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -18,12 +19,12 @@ export const SearchBox = ({ properties }: Props) => {
   const filters = useMemo(() => {
     const newFilters: Record<string, string> = {};
     searchParams.forEach((value, key) => {
-      if (key !== "search" && key !== "monsterId") {
+      if (key !== "search" && key !== selectedParamName) {
         newFilters[key] = value;
       }
     });
     return newFilters;
-  }, [searchParams]);
+  }, [searchParams, selectedParamName]);
 
   const handleSearchChange = (value: string) => {
     setInputValue(value);
@@ -57,9 +58,9 @@ export const SearchBox = ({ properties }: Props) => {
     for (const [key, value] of Object.entries(newFilters)) {
       params.set(key, value);
     }
-    const monsterId = searchParams.get("monsterId");
-    if (monsterId) {
-      params.set("monsterId", monsterId);
+    const selectedId = searchParams.get(selectedParamName);
+    if (selectedId) {
+      params.set(selectedParamName, selectedId);
     }
     router.replace(`${pathname}?${params.toString()}`);
   };

--- a/lib/spells/open5e.test.ts
+++ b/lib/spells/open5e.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildOpen5eSpellListUrl,
+  isOpen5eSpellId,
+  mergeSpellRows,
+  shouldShowSpellTableLoading,
+  toOpen5eSpell,
+  toOpen5eSpellBase,
+} from "./open5e.ts";
+
+test("maps an Open5e spell list result to the table row shape with a namespaced id", () => {
+  const row = toOpen5eSpellBase({
+    slug: "acid-arrow",
+    name: "Acid Arrow",
+    level_int: 2,
+    school: "Evocation",
+    casting_time: "1 action",
+    range: "90 feet",
+    dnd_class: "Druid, Wizard",
+    document__slug: "wotc-srd",
+    document__title: "5e Core Rules",
+  });
+
+  assert.deepEqual(row, {
+    id: "open5e:acid-arrow",
+    name: "Acid Arrow",
+    level: 2,
+    school: "Evocation",
+    castingTime: "1 action",
+    range: "90 feet",
+    classes: ["Druid", "Wizard"],
+    source: "5e Core Rules",
+  });
+  assert.equal(isOpen5eSpellId(row.id), true);
+});
+
+test("maps an Open5e spell detail result to the spell detail shape", () => {
+  const spell = toOpen5eSpell({
+    slug: "acid-arrow",
+    name: "Acid Arrow",
+    desc: "A shimmering green arrow streaks toward a target within range.",
+    higher_level:
+      "When you cast this spell using a spell slot of 3rd level or higher, the damage increases.",
+    page: "phb 259",
+    range: "90 feet",
+    target_range_sort: 90,
+    components: "V, S, M",
+    requires_verbal_components: true,
+    requires_somatic_components: true,
+    requires_material_components: true,
+    material: "Powdered rhubarb leaf and an adder's stomach.",
+    can_be_cast_as_ritual: false,
+    ritual: "no",
+    duration: "Instantaneous",
+    concentration: "no",
+    requires_concentration: false,
+    casting_time: "1 action",
+    level: "2nd-level",
+    level_int: 2,
+    spell_level: 2,
+    school: "Evocation",
+    dnd_class: "Druid, Wizard",
+    spell_lists: ["druid", "wizard"],
+    archetype: "Druid: Swamp",
+    circles: "Swamp",
+    document__slug: "wotc-srd",
+    document__title: "5e Core Rules",
+    document__license_url: "http://open5e.com/legal",
+    document__url: "http://dnd.wizards.com/articles/features/systems-reference-document-srd",
+  });
+
+  assert.equal(spell.id, "open5e:acid-arrow");
+  assert.equal(spell.source, "5e Core Rules");
+  assert.equal(spell.levelLabel, "2nd-level");
+  assert.deepEqual(spell.components, ["V", "S", "M"]);
+  assert.deepEqual(spell.classes, ["Druid", "Wizard"]);
+  assert.equal(spell.requiresConcentration, false);
+  assert.equal(spell.canBeCastAsRitual, false);
+  assert.equal(spell.url, "https://api.open5e.com/v1/spells/acid-arrow/");
+});
+
+test("builds Open5e list URLs from supported spell search params", () => {
+  const url = buildOpen5eSpellListUrl({
+    search: "acid",
+    filters: {
+      level: "2",
+      school: "Evocation",
+      class: "Wizard",
+      source: "wotc-srd",
+      unsupported: "ignored",
+    },
+  });
+
+  assert.equal(url.searchParams.get("limit"), "100");
+  assert.equal(url.searchParams.get("ordering"), "name");
+  assert.equal(url.searchParams.get("name__icontains"), "acid");
+  assert.equal(url.searchParams.get("spell_level"), "2");
+  assert.equal(url.searchParams.get("school"), "Evocation");
+  assert.equal(url.searchParams.get("dnd_class__icontains"), "Wizard");
+  assert.equal(url.searchParams.get("document__slug"), "wotc-srd");
+  assert.equal(url.searchParams.has("unsupported"), false);
+});
+
+test("merges Open5e and custom spell rows in name order without changing ids", () => {
+  const rows = mergeSpellRows(
+    [
+      {
+        id: "open5e:z",
+        name: "Zephyr Strike",
+        level: 1,
+        school: "Transmutation",
+        castingTime: "1 bonus action",
+        range: "Self",
+        classes: ["Ranger"],
+        source: "5e Core Rules",
+      },
+      {
+        id: "open5e:a",
+        name: "Acid Arrow",
+        level: 2,
+        school: "Evocation",
+        castingTime: "1 action",
+        range: "90 feet",
+        classes: ["Wizard"],
+        source: "5e Core Rules",
+      },
+    ],
+    [
+      {
+        id: "custom-1",
+        name: "Clockwork Spark",
+        level: 0,
+        school: "Evocation",
+        castingTime: "1 action",
+        range: "30 feet",
+        classes: ["Artificer"],
+        source: "Homebrew",
+      },
+    ]
+  );
+
+  assert.deepEqual(
+    rows.map((row) => row.id),
+    ["open5e:a", "custom-1", "open5e:z"]
+  );
+});
+
+test("does not block signed-out Open5e spell rows while Clerk is still loading", () => {
+  assert.equal(
+    shouldShowSpellTableLoading({
+      isOpen5ePending: false,
+      isSignedIn: undefined,
+      customRowsLoaded: false,
+    }),
+    false
+  );
+});

--- a/lib/spells/open5e.ts
+++ b/lib/spells/open5e.ts
@@ -1,0 +1,192 @@
+export const OPEN5E_SPELL_ID_PREFIX = "open5e:";
+
+export const SPELL_FILTER_PROPERTIES = ["level", "school", "class", "source"];
+
+export interface SpellBase {
+  id: string;
+  name: string;
+  level: number;
+  school: string;
+  castingTime: string;
+  range: string;
+  classes: string[];
+  source: string;
+}
+
+export interface Spell extends SpellBase {
+  index: string;
+  desc: string;
+  higherLevel?: string;
+  page?: string;
+  components: string[];
+  material?: string;
+  canBeCastAsRitual: boolean;
+  duration: string;
+  requiresConcentration: boolean;
+  levelLabel: string;
+  archetype?: string;
+  circles?: string;
+  url: string;
+}
+
+export interface Open5eSpellListItem {
+  slug: string;
+  name: string;
+  range: string;
+  casting_time: string;
+  level_int: number;
+  school: string;
+  dnd_class: string;
+  document__slug: string;
+  document__title: string;
+}
+
+export interface Open5eSpell extends Open5eSpellListItem {
+  desc: string;
+  higher_level?: string;
+  page?: string;
+  target_range_sort?: number | null;
+  components: string;
+  requires_verbal_components: boolean;
+  requires_somatic_components: boolean;
+  requires_material_components: boolean;
+  material?: string;
+  can_be_cast_as_ritual: boolean;
+  ritual: string;
+  duration: string;
+  concentration: string;
+  requires_concentration: boolean;
+  level: string;
+  spell_level: number;
+  spell_lists: string[];
+  archetype?: string;
+  circles?: string;
+  document__license_url?: string;
+  document__url?: string;
+}
+
+interface BuildOpen5eSpellListUrlArgs {
+  search?: string;
+  filters?: Record<string, string>;
+}
+
+interface SpellTableLoadingState {
+  isOpen5ePending: boolean;
+  isSignedIn: boolean | undefined;
+  customRowsLoaded: boolean;
+}
+
+export function isOpen5eSpellId(id: string) {
+  return id.startsWith(OPEN5E_SPELL_ID_PREFIX);
+}
+
+export function getOpen5eSpellSlugFromId(id: string) {
+  return isOpen5eSpellId(id) ? id.slice(OPEN5E_SPELL_ID_PREFIX.length) : id;
+}
+
+export function toOpen5eSpellId(slug: string) {
+  return `${OPEN5E_SPELL_ID_PREFIX}${slug}`;
+}
+
+export function toOpen5eSpellBase(spell: Open5eSpellListItem): SpellBase {
+  return {
+    id: toOpen5eSpellId(spell.slug),
+    name: spell.name,
+    level: spell.level_int,
+    school: spell.school,
+    castingTime: spell.casting_time,
+    range: spell.range,
+    classes: splitClasses(spell.dnd_class),
+    source: spell.document__title || spell.document__slug,
+  };
+}
+
+export function toOpen5eSpell(spell: Open5eSpell): Spell {
+  return {
+    ...toOpen5eSpellBase(spell),
+    index: spell.slug,
+    desc: spell.desc,
+    higherLevel: normalizeOptionalString(spell.higher_level),
+    page: normalizeOptionalString(spell.page),
+    components: splitComponents(spell.components),
+    material: normalizeOptionalString(spell.material),
+    canBeCastAsRitual: spell.can_be_cast_as_ritual,
+    duration: spell.duration,
+    requiresConcentration: spell.requires_concentration,
+    levelLabel: spell.level,
+    archetype: normalizeOptionalString(spell.archetype),
+    circles: normalizeOptionalString(spell.circles),
+    url: `https://api.open5e.com/v1/spells/${spell.slug}/`,
+  };
+}
+
+export function buildOpen5eSpellListUrl({ search, filters }: BuildOpen5eSpellListUrlArgs) {
+  const url = new URL("https://api.open5e.com/v1/spells/");
+  url.searchParams.set("limit", "100");
+  url.searchParams.set("ordering", "name");
+
+  if (search) {
+    url.searchParams.set("name__icontains", search);
+  }
+
+  for (const [key, value] of Object.entries(filters ?? {})) {
+    if (!value) {
+      continue;
+    }
+
+    if (key === "level") {
+      url.searchParams.set("spell_level", value);
+    }
+
+    if (key === "school") {
+      url.searchParams.set("school", value);
+    }
+
+    if (key === "class") {
+      url.searchParams.set("dnd_class__icontains", value);
+    }
+
+    if (key === "source") {
+      url.searchParams.set("document__slug", value);
+    }
+  }
+
+  return url;
+}
+
+export function mergeSpellRows(open5eRows: SpellBase[], customRows: SpellBase[]) {
+  return [...open5eRows, ...customRows].sort((left, right) =>
+    left.name.localeCompare(right.name, undefined, { sensitivity: "base" })
+  );
+}
+
+export function shouldShowSpellTableLoading({
+  isOpen5ePending,
+  isSignedIn,
+  customRowsLoaded,
+}: SpellTableLoadingState) {
+  return isOpen5ePending || (isSignedIn === true && !customRowsLoaded);
+}
+
+function splitClasses(value: string) {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function splitComponents(value: string) {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function normalizeOptionalString(value?: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Open5e spell API proxy routes and mapping helpers.
- Replace the spells placeholder with the bestiary-style search/list/detail layout.
- Preserve selected row query params through the shared search box.
- Wrap the search-param driven spells content in a Suspense boundary for App Router builds.

## Testing
- `node --experimental-strip-types --test lib/bestiary/open5e.test.ts lib/spells/open5e.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `NEXT_PUBLIC_CONVEX_URL=https://example.convex.cloud NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=<test-key> CLERK_SECRET_KEY=<test-key> pnpm build`
- `curl` smoke test for `/api/open5e/spells?search=acid` and `/api/open5e/spells/acid-arrow`

## Manual UI note
- Browser walkthrough was blocked by Clerk redirect because this environment does not have valid project Clerk credentials.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f748490-39cb-477a-8f13-9c8f6513e84d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f748490-39cb-477a-8f13-9c8f6513e84d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

