### PR TITLE
Add Open5e items reference

### DIFF
--- a/app/api/open5e/items/[slug]/route.ts
+++ b/app/api/open5e/items/[slug]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { toOpen5eItem, type Open5eItem } from "@/lib/items/open5e";
+
+interface RouteContext {
+  params: Promise<{
+    slug: string;
+  }>;
+}
+
+export async function GET(_request: Request, context: RouteContext) {
+  const { slug } = await context.params;
+  const response = await fetch(`https://api.open5e.com/v1/magicitems/${encodeURIComponent(slug)}/`, {
+    next: { revalidate: 60 * 60 },
+  });
+
+  if (!response.ok) {
+    return NextResponse.json({ error: "Failed to load Open5e item." }, { status: response.status });
+  }
+
+  const item = (await response.json()) as Open5eItem;
+  return NextResponse.json(toOpen5eItem(item));
+}

--- a/app/api/open5e/items/route.ts
+++ b/app/api/open5e/items/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import {
+  buildOpen5eItemListUrl,
+  toOpen5eItemBase,
+  type Open5eItemListItem,
+} from "@/lib/items/open5e";
+
+interface Open5eItemListResponse {
+  next: string | null;
+  results: Open5eItemListItem[];
+}
+
+const MAX_OPEN5E_PAGES = 40;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const search = searchParams.get("search") ?? undefined;
+  const filters = Object.fromEntries(searchParams.entries());
+  delete filters.search;
+
+  const items = [];
+  let nextUrl: string | null = buildOpen5eItemListUrl({ search, filters }).toString();
+  let pageCount = 0;
+
+  while (nextUrl && pageCount < MAX_OPEN5E_PAGES) {
+    const response = await fetch(nextUrl, { next: { revalidate: 60 * 60 } });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: "Failed to load Open5e items." },
+        { status: response.status }
+      );
+    }
+
+    const page = (await response.json()) as Open5eItemListResponse;
+    items.push(...page.results.map(toOpen5eItemBase));
+    nextUrl = page.next;
+    pageCount += 1;
+  }
+
+  return NextResponse.json({ results: items });
+}

--- a/app/references/items/columns.tsx
+++ b/app/references/items/columns.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { ColumnDef } from "@tanstack/react-table";
+import { ItemBase } from "./type";
+
+export const columns: ColumnDef<ItemBase>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "type",
+    header: "Type",
+  },
+  {
+    accessorKey: "rarity",
+    header: "Rarity",
+  },
+  {
+    accessorKey: "requiresAttunement",
+    header: "Attunement",
+    cell: ({ row }) => (row.original.requiresAttunement ? "Yes" : "No"),
+  },
+  {
+    accessorKey: "source",
+    header: "Source",
+  },
+];

--- a/app/references/items/data-table.tsx
+++ b/app/references/items/data-table.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useUser } from "@clerk/nextjs";
+import { useQuery as useReactQuery } from "@tanstack/react-query";
+import { flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import { LoaderPinwheelIcon } from "lucide-react";
+import { useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { mergeItemRows, shouldShowItemTableLoading } from "@/lib/items/open5e";
+import { columns } from "./columns";
+import type { ItemBase } from "./type";
+
+interface Open5eItemListResponse {
+  results: ItemBase[];
+}
+
+const EMPTY_ITEM_ROWS: ItemBase[] = [];
+
+async function fetchOpen5eItems(search: string | undefined, filters: Record<string, string>) {
+  const params = new URLSearchParams();
+
+  if (search) {
+    params.set("search", search);
+  }
+
+  for (const [key, value] of Object.entries(filters)) {
+    params.set(key, value);
+  }
+
+  const response = await fetch(`/api/open5e/items?${params.toString()}`);
+
+  if (!response.ok) {
+    throw new Error("Failed to load Open5e items.");
+  }
+
+  const data = (await response.json()) as Open5eItemListResponse;
+  return data.results;
+}
+
+export default function DataTable() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isSignedIn } = useUser();
+  const search = searchParams.get("search");
+  const filters = useMemo(() => {
+    const nextFilters: Record<string, string> = {};
+    searchParams.forEach((value, key) => {
+      if (key !== "search" && key !== "itemId") {
+        nextFilters[key] = value;
+      }
+    });
+    return nextFilters;
+  }, [searchParams]);
+
+  const open5eItems = useReactQuery({
+    queryKey: ["open5e-items", search, filters],
+    queryFn: () => fetchOpen5eItems(search ?? undefined, filters),
+  });
+  const items = useMemo(() => {
+    if (!open5eItems.data) {
+      return EMPTY_ITEM_ROWS;
+    }
+
+    return mergeItemRows(open5eItems.data, EMPTY_ITEM_ROWS);
+  }, [open5eItems.data]);
+  const isLoading = shouldShowItemTableLoading({
+    isOpen5ePending: open5eItems.isPending,
+    isSignedIn,
+    customRowsLoaded: true,
+  });
+
+  // TanStack Table exposes function properties that React Compiler cannot memoize safely.
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data: items,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  const handleRowClick = (itemId: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("itemId", itemId);
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
+  return !isLoading ? (
+    <div className="h-full flex flex-col">
+      <ScrollArea className="h-full w-full rounded-md border">
+        <div className="h-full w-full">
+          <Table>
+            <TableHeader className="sticky top-0 bg-background z-10">
+              {table.getHeaderGroups().map((headerGroup) => (
+                <TableRow key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <TableHead key={header.id}>
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(header.column.columnDef.header, header.getContext())}
+                    </TableHead>
+                  ))}
+                </TableRow>
+              ))}
+            </TableHeader>
+            <TableBody>
+              {open5eItems.isError ? (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-24 text-center">
+                    Unable to load Open5e items.
+                  </TableCell>
+                </TableRow>
+              ) : table.getRowModel().rows.length ? (
+                table.getRowModel().rows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    className="cursor-pointer"
+                    data-state={row.getIsSelected() ? "selected" : ""}
+                    onClick={() => handleRowClick(row.original.id)}>
+                    {row.getVisibleCells().map((cell) => (
+                      <TableCell key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell colSpan={columns.length} className="h-24 text-center">
+                    No results.
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </ScrollArea>
+    </div>
+  ) : (
+    <div className="h-full flex items-center justify-center">
+      <LoaderPinwheelIcon className="animate-spin" />
+    </div>
+  );
+}

--- a/app/references/items/itemView.tsx
+++ b/app/references/items/itemView.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useQuery as useReactQuery } from "@tanstack/react-query";
+import { LoaderPinwheelIcon, X } from "lucide-react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { getOpen5eItemSlugFromId } from "@/lib/items/open5e";
+import type { Item } from "./type";
+
+async function fetchOpen5eItem(itemId: string) {
+  const slug = getOpen5eItemSlugFromId(itemId);
+  const response = await fetch(`/api/open5e/items/${encodeURIComponent(slug)}`);
+
+  if (!response.ok) {
+    throw new Error("Failed to load Open5e item.");
+  }
+
+  return (await response.json()) as Item;
+}
+
+export default function ItemView() {
+  const params = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const itemId = params.get("itemId");
+
+  const open5eItem = useReactQuery({
+    queryKey: ["open5e-item", itemId],
+    queryFn: () => fetchOpen5eItem(itemId!),
+    enabled: !!itemId,
+  });
+
+  const handleClose = () => {
+    const newParams = new URLSearchParams(params);
+    newParams.delete("itemId");
+    router.push(`${pathname}?${newParams.toString()}`);
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      {open5eItem.isPending ? (
+        <div className="h-full flex items-center justify-center">
+          <LoaderPinwheelIcon className="animate-spin" />
+        </div>
+      ) : open5eItem.isError ? (
+        <div className="h-full flex items-center justify-center text-muted-foreground">
+          Unable to load selected Open5e item.
+        </div>
+      ) : open5eItem.data ? (
+        <Card className="h-full flex flex-col">
+          <CardHeader className="flex-shrink-0">
+            <div className="flex justify-between items-center scroll-m-20 border-b pb-2">
+              <div>
+                <CardTitle className="text-3xl font-semibold tracking-tight first:mt-0">
+                  {open5eItem.data.name}
+                </CardTitle>
+                <p className="text-muted-foreground">
+                  {open5eItem.data.rarity} {open5eItem.data.type}
+                </p>
+              </div>
+              <Button variant="ghost" size="icon" onClick={handleClose}>
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="flex-1 min-h-0">
+            <ScrollArea className="h-full">
+              <div className="flex flex-col gap-4">
+                <section className="grid gap-2">
+                  <p className="leading-7">
+                    <b>Type:</b> {open5eItem.data.type}
+                  </p>
+                  <p className="leading-7">
+                    <b>Rarity:</b> {open5eItem.data.rarity || "--"}
+                  </p>
+                  <p className="leading-7">
+                    <b>Attunement:</b> {open5eItem.data.requiresAttunement || "Not required"}
+                  </p>
+                </section>
+                <section>
+                  <p className="leading-7 whitespace-pre-line">{open5eItem.data.desc}</p>
+                </section>
+                <div className="flex flex-row-reverse">
+                  <p className="leading-7 text-gray-500">Source: {open5eItem.data.source}</p>
+                </div>
+              </div>
+            </ScrollArea>
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/app/references/items/layout.tsx
+++ b/app/references/items/layout.tsx
@@ -1,0 +1,25 @@
+import { LoaderPinwheelIcon } from "lucide-react";
+import { Metadata } from "next";
+import { Suspense } from "react";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export const metadata: Metadata = {
+  title: "Items - Chronicler's Desk",
+  description: "A searchable magic item reference.",
+};
+
+export default async function ItemsLayout({ children }: Props) {
+  return (
+    <Suspense
+      fallback={
+        <div className="w-full h-screen flex items-center justify-center">
+          <LoaderPinwheelIcon className="animate-spin" />
+        </div>
+      }>
+      {children}
+    </Suspense>
+  );
+}

--- a/app/references/items/page.tsx
+++ b/app/references/items/page.tsx
@@ -1,18 +1,40 @@
+"use client";
+
 import { PageHeader } from "@/components/PageHeader";
+import { SearchBox } from "@/components/SearchBox";
+import { ITEM_FILTER_PROPERTIES } from "@/lib/items/open5e";
+import { useSearchParams } from "next/navigation";
+import DataTable from "./data-table";
+import ItemView from "./itemView";
 
 export default function Items() {
+  const searchParams = useSearchParams();
+  const itemId = searchParams.get("itemId");
+
   const breadcrumbItems = [
     { label: "Home", href: "/" },
-    { 
-      label: "References", 
+    {
+      label: "References",
       href: "/references",
       dropdownOptions: [
-        { label: "Bestiary", href: "/references/bestiary", description: "Browse monsters and creatures" },
-        { label: "Spells", href: "/references/spells", description: "Search magical spells and abilities" },
-        { label: "Items", href: "/references/items", description: "Discover magical items and equipment" }
-      ]
+        {
+          label: "Bestiary",
+          href: "/references/bestiary",
+          description: "Browse monsters and creatures",
+        },
+        {
+          label: "Spells",
+          href: "/references/spells",
+          description: "Search magical spells and abilities",
+        },
+        {
+          label: "Items",
+          href: "/references/items",
+          description: "Discover magical items and equipment",
+        },
+      ],
     },
-    { label: "Items", isCurrentPage: true }
+    { label: "Items", isCurrentPage: true },
   ];
 
   return (
@@ -22,12 +44,31 @@ export default function Items() {
         description="Discover magical items and equipment"
         breadcrumbItems={breadcrumbItems}
       />
-
-      <main className="container mx-auto px-4 py-8">
-        <div className="text-center">
-          <p className="text-muted-foreground">Items reference content coming soon...</p>
-        </div>
-      </main>
+      {itemId ? (
+        <main className="px-4 pt-6 h-[calc(100vh-200px)]">
+          <div className="grid h-full grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] gap-4">
+            <section className="flex flex-col min-h-0">
+              <SearchBox properties={ITEM_FILTER_PROPERTIES} selectedParamName="itemId" />
+              <div className="h-full overflow-hidden">
+                <DataTable />
+              </div>
+            </section>
+            <div className="w-px bg-border" aria-hidden="true" />
+            <section className="flex flex-col min-h-0">
+              <div className="h-full overflow-hidden">
+                <ItemView />
+              </div>
+            </section>
+          </div>
+        </main>
+      ) : (
+        <main className="px-4 pt-6 h-[calc(100vh-250px)]">
+          <SearchBox properties={ITEM_FILTER_PROPERTIES} selectedParamName="itemId" />
+          <div className="h-full w-full">
+            <DataTable />
+          </div>
+        </main>
+      )}
     </div>
   );
 }

--- a/app/references/items/type.ts
+++ b/app/references/items/type.ts
@@ -1,0 +1,15 @@
+export interface ItemBase {
+  id: string;
+  name: string;
+  type: string;
+  rarity: string;
+  requiresAttunement?: string;
+  source: string;
+}
+
+export interface Item extends ItemBase {
+  index: string;
+  desc: string;
+  documentUrl?: string;
+  url: string;
+}

--- a/lib/items/open5e.test.ts
+++ b/lib/items/open5e.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildOpen5eItemListUrl,
+  isOpen5eItemId,
+  mergeItemRows,
+  shouldShowItemTableLoading,
+  toOpen5eItem,
+  toOpen5eItemBase,
+} from "./open5e.ts";
+
+test("maps an Open5e magic item list result to the table row shape with a namespaced id", () => {
+  const row = toOpen5eItemBase({
+    slug: "bag-of-holding",
+    name: "Bag of Holding",
+    type: "Wondrous Item",
+    desc: "This bag has an interior space considerably larger than its outside dimensions.",
+    rarity: "uncommon",
+    requires_attunement: "",
+    document__slug: "wotc-srd",
+    document__title: "5e Core Rules",
+    document__url: "https://example.com/srd",
+  });
+
+  assert.deepEqual(row, {
+    id: "open5e:bag-of-holding",
+    name: "Bag of Holding",
+    type: "Wondrous Item",
+    rarity: "uncommon",
+    requiresAttunement: undefined,
+    source: "5e Core Rules",
+  });
+  assert.equal(isOpen5eItemId(row.id), true);
+});
+
+test("maps an Open5e magic item detail result to the item detail shape", () => {
+  const item = toOpen5eItem({
+    slug: "cloak-of-protection",
+    name: "Cloak of Protection",
+    type: "Wondrous Item",
+    desc: "You gain a +1 bonus to AC and saving throws while you wear this cloak.",
+    rarity: "uncommon",
+    requires_attunement: "requires attunement",
+    document__slug: "wotc-srd",
+    document__title: "5e Core Rules",
+    document__url: "https://example.com/srd",
+  });
+
+  assert.equal(item.id, "open5e:cloak-of-protection");
+  assert.equal(item.source, "5e Core Rules");
+  assert.equal(item.index, "cloak-of-protection");
+  assert.equal(item.requiresAttunement, "requires attunement");
+  assert.equal(item.url, "https://api.open5e.com/v1/magicitems/cloak-of-protection/");
+  assert.equal(item.documentUrl, "https://example.com/srd");
+});
+
+test("builds Open5e list URLs from supported item search params", () => {
+  const url = buildOpen5eItemListUrl({
+    search: "cloak",
+    filters: {
+      type: "Wondrous Item",
+      rarity: "uncommon",
+      requiresAttunement: "requires attunement",
+      source: "wotc-srd",
+      unsupported: "ignored",
+    },
+  });
+
+  assert.equal(url.searchParams.get("limit"), "100");
+  assert.equal(url.searchParams.get("ordering"), "name");
+  assert.equal(url.searchParams.get("name__icontains"), "cloak");
+  assert.equal(url.searchParams.get("type"), "Wondrous Item");
+  assert.equal(url.searchParams.get("rarity"), "uncommon");
+  assert.equal(url.searchParams.get("requires_attunement"), "requires attunement");
+  assert.equal(url.searchParams.get("document__slug"), "wotc-srd");
+  assert.equal(url.searchParams.has("unsupported"), false);
+});
+
+test("merges Open5e and custom item rows in name order without changing ids", () => {
+  const rows = mergeItemRows(
+    [
+      {
+        id: "open5e:z",
+        name: "Zephyr Blade",
+        type: "Weapon",
+        rarity: "rare",
+        requiresAttunement: "requires attunement",
+        source: "5e Core Rules",
+      },
+      {
+        id: "open5e:a",
+        name: "Amulet of Health",
+        type: "Wondrous Item",
+        rarity: "rare",
+        requiresAttunement: "requires attunement",
+        source: "5e Core Rules",
+      },
+    ],
+    [
+      {
+        id: "custom-1",
+        name: "Clockwork Compass",
+        type: "Wondrous Item",
+        rarity: "uncommon",
+        requiresAttunement: undefined,
+        source: "Homebrew",
+      },
+    ]
+  );
+
+  assert.deepEqual(
+    rows.map((row) => row.id),
+    ["open5e:a", "custom-1", "open5e:z"]
+  );
+});
+
+test("does not block signed-out Open5e item rows while Clerk is still loading", () => {
+  assert.equal(
+    shouldShowItemTableLoading({
+      isOpen5ePending: false,
+      isSignedIn: undefined,
+      customRowsLoaded: false,
+    }),
+    false
+  );
+});

--- a/lib/items/open5e.ts
+++ b/lib/items/open5e.ts
@@ -1,0 +1,134 @@
+export const OPEN5E_ITEM_ID_PREFIX = "open5e:";
+
+export const ITEM_FILTER_PROPERTIES = ["type", "rarity", "requiresAttunement", "source"];
+
+export interface ItemBase {
+  id: string;
+  name: string;
+  type: string;
+  rarity: string;
+  requiresAttunement?: string;
+  source: string;
+}
+
+export interface Item extends ItemBase {
+  index: string;
+  desc: string;
+  documentUrl?: string;
+  url: string;
+}
+
+export interface Open5eItemListItem {
+  slug: string;
+  name: string;
+  type: string;
+  desc: string;
+  rarity: string;
+  requires_attunement: string;
+  document__slug: string;
+  document__title: string;
+  document__url?: string;
+}
+
+export type Open5eItem = Open5eItemListItem;
+
+interface BuildOpen5eItemListUrlArgs {
+  search?: string;
+  filters?: Record<string, string>;
+}
+
+interface ItemTableLoadingState {
+  isOpen5ePending: boolean;
+  isSignedIn: boolean | undefined;
+  customRowsLoaded: boolean;
+}
+
+export function isOpen5eItemId(id: string) {
+  return id.startsWith(OPEN5E_ITEM_ID_PREFIX);
+}
+
+export function getOpen5eItemSlugFromId(id: string) {
+  return isOpen5eItemId(id) ? id.slice(OPEN5E_ITEM_ID_PREFIX.length) : id;
+}
+
+export function toOpen5eItemId(slug: string) {
+  return `${OPEN5E_ITEM_ID_PREFIX}${slug}`;
+}
+
+export function toOpen5eItemBase(item: Open5eItemListItem): ItemBase {
+  return {
+    id: toOpen5eItemId(item.slug),
+    name: item.name,
+    type: item.type,
+    rarity: item.rarity,
+    requiresAttunement: normalizeOptionalString(item.requires_attunement),
+    source: item.document__title || item.document__slug,
+  };
+}
+
+export function toOpen5eItem(item: Open5eItem): Item {
+  return {
+    ...toOpen5eItemBase(item),
+    index: item.slug,
+    desc: item.desc,
+    documentUrl: normalizeOptionalString(item.document__url),
+    url: `https://api.open5e.com/v1/magicitems/${item.slug}/`,
+  };
+}
+
+export function buildOpen5eItemListUrl({ search, filters }: BuildOpen5eItemListUrlArgs) {
+  const url = new URL("https://api.open5e.com/v1/magicitems/");
+  url.searchParams.set("limit", "100");
+  url.searchParams.set("ordering", "name");
+
+  if (search) {
+    url.searchParams.set("name__icontains", search);
+  }
+
+  for (const [key, value] of Object.entries(filters ?? {})) {
+    if (!value) {
+      continue;
+    }
+
+    if (key === "type") {
+      url.searchParams.set("type", value);
+    }
+
+    if (key === "rarity") {
+      url.searchParams.set("rarity", value);
+    }
+
+    if (key === "requiresAttunement") {
+      url.searchParams.set("requires_attunement", value);
+    }
+
+    if (key === "source") {
+      url.searchParams.set("document__slug", value);
+    }
+  }
+
+  return url;
+}
+
+export function mergeItemRows(open5eRows: ItemBase[], customRows: ItemBase[]) {
+  return [...open5eRows, ...customRows].sort((left, right) =>
+    left.name.localeCompare(right.name, undefined, { sensitivity: "base" })
+  );
+}
+
+export function shouldShowItemTableLoading({
+  isOpen5ePending,
+  isSignedIn,
+  customRowsLoaded,
+}: ItemTableLoadingState) {
+  return isOpen5ePending || (isSignedIn === true && !customRowsLoaded);
+}
+
+function normalizeOptionalString(value?: string | null) {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ["127.0.0.1"],
   reactCompiler: true,
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add Open5e magic item mapping helpers and unit tests.
- Add item list and detail API proxy routes.
- Replace the items placeholder with a bestiary-style search/table/detail layout.
- Allow `127.0.0.1` as a Next dev origin so local browser testing hydrates correctly.

## Walkthrough
[open5e_items_reference_walkthrough.mp4](https://cursor.com/agents/bc-510201e9-3c2e-4ee7-82de-c8848112371f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopen5e_items_reference_walkthrough.mp4)
[Items split detail view](https://cursor.com/agents/bc-510201e9-3c2e-4ee7-82de-c8848112371f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fitems_split_detail.webp)
[Items table after closing detail](https://cursor.com/agents/bc-510201e9-3c2e-4ee7-82de-c8848112371f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fitems_table_after_close.webp)

## Testing
- `node --test "lib/bestiary/open5e.test.ts" "lib/spells/open5e.test.ts" "lib/items/open5e.test.ts"`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- Local API probe against `http://127.0.0.1:3000/api/open5e/items?search=bag&type=Wondrous%20Item` and `http://127.0.0.1:3000/api/open5e/items/bag-of-holding/`
- Browser walkthrough of items search, split detail view, and close behavior.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-510201e9-3c2e-4ee7-82de-c8848112371f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-510201e9-3c2e-4ee7-82de-c8848112371f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

