### PR TITLE
Cache Open5e reference fetches

### DIFF
--- a/app/api/open5e/items/[slug]/route.ts
+++ b/app/api/open5e/items/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { toOpen5eItem, type Open5eItem } from "@/lib/items/open5e";
+import { fetchOpen5eJson, OPEN5E_CACHE_HEADERS, Open5eFetchError } from "@/lib/open5e/cache";
 
 interface RouteContext {
   params: Promise<{
@@ -9,14 +10,17 @@ interface RouteContext {
 
 export async function GET(_request: Request, context: RouteContext) {
   const { slug } = await context.params;
-  const response = await fetch(`https://api.open5e.com/v1/magicitems/${encodeURIComponent(slug)}/`, {
-    next: { revalidate: 60 * 60 },
-  });
 
-  if (!response.ok) {
-    return NextResponse.json({ error: "Failed to load Open5e item." }, { status: response.status });
+  try {
+    const item = await fetchOpen5eJson<Open5eItem>(
+      `https://api.open5e.com/v1/magicitems/${encodeURIComponent(slug)}/`
+    );
+
+    return NextResponse.json(toOpen5eItem(item), { headers: OPEN5E_CACHE_HEADERS });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to load Open5e item." },
+      { status: error instanceof Open5eFetchError ? error.status : 502 }
+    );
   }
-
-  const item = (await response.json()) as Open5eItem;
-  return NextResponse.json(toOpen5eItem(item));
 }

--- a/app/api/open5e/items/route.ts
+++ b/app/api/open5e/items/route.ts
@@ -4,13 +4,7 @@ import {
   toOpen5eItemBase,
   type Open5eItemListItem,
 } from "@/lib/items/open5e";
-
-interface Open5eItemListResponse {
-  next: string | null;
-  results: Open5eItemListItem[];
-}
-
-const MAX_OPEN5E_PAGES = 40;
+import { fetchOpen5eList, OPEN5E_CACHE_HEADERS, Open5eFetchError } from "@/lib/open5e/cache";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -18,25 +12,17 @@ export async function GET(request: Request) {
   const filters = Object.fromEntries(searchParams.entries());
   delete filters.search;
 
-  const items = [];
-  let nextUrl: string | null = buildOpen5eItemListUrl({ search, filters }).toString();
-  let pageCount = 0;
+  try {
+    const items = await fetchOpen5eList<Open5eItemListItem, ReturnType<typeof toOpen5eItemBase>>({
+      initialUrl: buildOpen5eItemListUrl({ search, filters }),
+      mapResult: toOpen5eItemBase,
+    });
 
-  while (nextUrl && pageCount < MAX_OPEN5E_PAGES) {
-    const response = await fetch(nextUrl, { next: { revalidate: 60 * 60 } });
-
-    if (!response.ok) {
-      return NextResponse.json(
-        { error: "Failed to load Open5e items." },
-        { status: response.status }
-      );
-    }
-
-    const page = (await response.json()) as Open5eItemListResponse;
-    items.push(...page.results.map(toOpen5eItemBase));
-    nextUrl = page.next;
-    pageCount += 1;
+    return NextResponse.json({ results: items }, { headers: OPEN5E_CACHE_HEADERS });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to load Open5e items." },
+      { status: error instanceof Open5eFetchError ? error.status : 502 }
+    );
   }
-
-  return NextResponse.json({ results: items });
 }

--- a/app/api/open5e/monsters/[slug]/route.ts
+++ b/app/api/open5e/monsters/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { toOpen5eMonster, type Open5eMonster } from "@/lib/bestiary/open5e";
+import { fetchOpen5eJson, OPEN5E_CACHE_HEADERS, Open5eFetchError } from "@/lib/open5e/cache";
 
 interface RouteContext {
   params: Promise<{
@@ -9,17 +10,17 @@ interface RouteContext {
 
 export async function GET(_request: Request, context: RouteContext) {
   const { slug } = await context.params;
-  const response = await fetch(`https://api.open5e.com/v1/monsters/${encodeURIComponent(slug)}/`, {
-    next: { revalidate: 60 * 60 },
-  });
 
-  if (!response.ok) {
+  try {
+    const monster = await fetchOpen5eJson<Open5eMonster>(
+      `https://api.open5e.com/v1/monsters/${encodeURIComponent(slug)}/`
+    );
+
+    return NextResponse.json(toOpen5eMonster(monster), { headers: OPEN5E_CACHE_HEADERS });
+  } catch (error) {
     return NextResponse.json(
       { error: "Failed to load Open5e monster." },
-      { status: response.status }
+      { status: error instanceof Open5eFetchError ? error.status : 502 }
     );
   }
-
-  const monster = (await response.json()) as Open5eMonster;
-  return NextResponse.json(toOpen5eMonster(monster));
 }

--- a/app/api/open5e/monsters/route.ts
+++ b/app/api/open5e/monsters/route.ts
@@ -4,13 +4,7 @@ import {
   toOpen5eMonsterBase,
   type Open5eMonsterListItem,
 } from "@/lib/bestiary/open5e";
-
-interface Open5eListResponse {
-  next: string | null;
-  results: Open5eMonsterListItem[];
-}
-
-const MAX_OPEN5E_PAGES = 40;
+import { fetchOpen5eList, OPEN5E_CACHE_HEADERS, Open5eFetchError } from "@/lib/open5e/cache";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -18,25 +12,17 @@ export async function GET(request: Request) {
   const filters = Object.fromEntries(searchParams.entries());
   delete filters.search;
 
-  const monsters = [];
-  let nextUrl: string | null = buildOpen5eListUrl({ search, filters }).toString();
-  let pageCount = 0;
+  try {
+    const monsters = await fetchOpen5eList<Open5eMonsterListItem, ReturnType<typeof toOpen5eMonsterBase>>({
+      initialUrl: buildOpen5eListUrl({ search, filters }),
+      mapResult: toOpen5eMonsterBase,
+    });
 
-  while (nextUrl && pageCount < MAX_OPEN5E_PAGES) {
-    const response = await fetch(nextUrl, { next: { revalidate: 60 * 60 } });
-
-    if (!response.ok) {
-      return NextResponse.json(
-        { error: "Failed to load Open5e monsters." },
-        { status: response.status }
-      );
-    }
-
-    const page = (await response.json()) as Open5eListResponse;
-    monsters.push(...page.results.map(toOpen5eMonsterBase));
-    nextUrl = page.next;
-    pageCount += 1;
+    return NextResponse.json({ results: monsters }, { headers: OPEN5E_CACHE_HEADERS });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to load Open5e monsters." },
+      { status: error instanceof Open5eFetchError ? error.status : 502 }
+    );
   }
-
-  return NextResponse.json({ results: monsters });
 }

--- a/app/api/open5e/spells/[slug]/route.ts
+++ b/app/api/open5e/spells/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { toOpen5eSpell, type Open5eSpell } from "@/lib/spells/open5e";
+import { fetchOpen5eJson, OPEN5E_CACHE_HEADERS, Open5eFetchError } from "@/lib/open5e/cache";
 
 interface RouteContext {
   params: Promise<{
@@ -9,14 +10,17 @@ interface RouteContext {
 
 export async function GET(_request: Request, context: RouteContext) {
   const { slug } = await context.params;
-  const response = await fetch(`https://api.open5e.com/v1/spells/${encodeURIComponent(slug)}/`, {
-    next: { revalidate: 60 * 60 },
-  });
 
-  if (!response.ok) {
-    return NextResponse.json({ error: "Failed to load Open5e spell." }, { status: response.status });
+  try {
+    const spell = await fetchOpen5eJson<Open5eSpell>(
+      `https://api.open5e.com/v1/spells/${encodeURIComponent(slug)}/`
+    );
+
+    return NextResponse.json(toOpen5eSpell(spell), { headers: OPEN5E_CACHE_HEADERS });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to load Open5e spell." },
+      { status: error instanceof Open5eFetchError ? error.status : 502 }
+    );
   }
-
-  const spell = (await response.json()) as Open5eSpell;
-  return NextResponse.json(toOpen5eSpell(spell));
 }

--- a/app/api/open5e/spells/route.ts
+++ b/app/api/open5e/spells/route.ts
@@ -4,13 +4,7 @@ import {
   toOpen5eSpellBase,
   type Open5eSpellListItem,
 } from "@/lib/spells/open5e";
-
-interface Open5eSpellListResponse {
-  next: string | null;
-  results: Open5eSpellListItem[];
-}
-
-const MAX_OPEN5E_PAGES = 40;
+import { fetchOpen5eList, OPEN5E_CACHE_HEADERS, Open5eFetchError } from "@/lib/open5e/cache";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -18,22 +12,17 @@ export async function GET(request: Request) {
   const filters = Object.fromEntries(searchParams.entries());
   delete filters.search;
 
-  const spells = [];
-  let nextUrl: string | null = buildOpen5eSpellListUrl({ search, filters }).toString();
-  let pageCount = 0;
+  try {
+    const spells = await fetchOpen5eList<Open5eSpellListItem, ReturnType<typeof toOpen5eSpellBase>>({
+      initialUrl: buildOpen5eSpellListUrl({ search, filters }),
+      mapResult: toOpen5eSpellBase,
+    });
 
-  while (nextUrl && pageCount < MAX_OPEN5E_PAGES) {
-    const response = await fetch(nextUrl, { next: { revalidate: 60 * 60 } });
-
-    if (!response.ok) {
-      return NextResponse.json({ error: "Failed to load Open5e spells." }, { status: response.status });
-    }
-
-    const page = (await response.json()) as Open5eSpellListResponse;
-    spells.push(...page.results.map(toOpen5eSpellBase));
-    nextUrl = page.next;
-    pageCount += 1;
+    return NextResponse.json({ results: spells }, { headers: OPEN5E_CACHE_HEADERS });
+  } catch (error) {
+    return NextResponse.json(
+      { error: "Failed to load Open5e spells." },
+      { status: error instanceof Open5eFetchError ? error.status : 502 }
+    );
   }
-
-  return NextResponse.json({ results: spells });
 }

--- a/app/providers/QueryProvider.tsx
+++ b/app/providers/QueryProvider.tsx
@@ -13,7 +13,9 @@ export default function QueryProvider({ children }: QueryProviderProps) {
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: 60 * 1000,
+            gcTime: 60 * 60 * 1000,
+            refetchOnWindowFocus: false,
+            staleTime: 15 * 60 * 1000,
           },
         },
       })

--- a/lib/open5e/cache.test.ts
+++ b/lib/open5e/cache.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clearOpen5eResponseCache,
+  fetchOpen5eJson,
+  fetchOpen5eList,
+} from "./cache.ts";
+
+test("reuses cached Open5e responses and dedupes concurrent requests", async () => {
+  clearOpen5eResponseCache();
+
+  let calls = 0;
+  const fetchFn: typeof fetch = async () => {
+    calls += 1;
+    return Response.json({ value: calls });
+  };
+
+  const url = "https://api.open5e.com/v1/spells/?limit=100";
+  const [first, second] = await Promise.all([
+    fetchOpen5eJson<{ value: number }>(url, { fetchFn }),
+    fetchOpen5eJson<{ value: number }>(url, { fetchFn }),
+  ]);
+  const third = await fetchOpen5eJson<{ value: number }>(url, { fetchFn });
+
+  assert.deepEqual(first, { value: 1 });
+  assert.deepEqual(second, { value: 1 });
+  assert.deepEqual(third, { value: 1 });
+  assert.equal(calls, 1);
+});
+
+test("loads remaining Open5e list pages in parallel when count is available", async () => {
+  clearOpen5eResponseCache();
+
+  const fetchedOffsets: number[] = [];
+  const fetchFn: typeof fetch = async (input) => {
+    const url = new URL(String(input));
+    const offset = Number(url.searchParams.get("offset") ?? "0");
+    fetchedOffsets.push(offset);
+
+    return Response.json({
+      count: 250,
+      next: offset === 200 ? null : "https://api.open5e.com/v1/monsters/",
+      results: [{ offset }],
+    });
+  };
+
+  const results = await fetchOpen5eList({
+    initialUrl: new URL("https://api.open5e.com/v1/monsters/?limit=100"),
+    fetchFn,
+    mapResult: (result: { offset: number }) => result.offset,
+  });
+
+  assert.deepEqual(results, [0, 100, 200]);
+  assert.deepEqual(fetchedOffsets, [0, 100, 200]);
+});

--- a/lib/open5e/cache.ts
+++ b/lib/open5e/cache.ts
@@ -1,0 +1,213 @@
+export const OPEN5E_REVALIDATE_SECONDS = 60 * 60;
+
+export const OPEN5E_CACHE_HEADERS = {
+  "Cache-Control": `public, max-age=300, s-maxage=${OPEN5E_REVALIDATE_SECONDS}, stale-while-revalidate=${OPEN5E_REVALIDATE_SECONDS}`,
+};
+
+const OPEN5E_RESPONSE_CACHE_TTL_MS = OPEN5E_REVALIDATE_SECONDS * 1000;
+const OPEN5E_LIST_LIMIT = 100;
+const DEFAULT_MAX_OPEN5E_PAGES = 40;
+
+interface CacheEntry<T> {
+  expiresAt: number;
+  promise: Promise<T>;
+}
+
+interface FetchOpen5eJsonOptions {
+  fetchFn?: typeof fetch;
+  now?: () => number;
+  ttlMs?: number;
+}
+
+interface Open5eListResponse<T> {
+  count?: number;
+  next: string | null;
+  results: T[];
+}
+
+interface FetchOpen5eListOptions<TSource, TResult> extends FetchOpen5eJsonOptions {
+  initialUrl: URL;
+  mapResult: (result: TSource) => TResult;
+  maxPages?: number;
+}
+
+const responseCache = new Map<string, CacheEntry<unknown>>();
+
+export class Open5eFetchError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "Open5eFetchError";
+    this.status = status;
+  }
+}
+
+export function clearOpen5eResponseCache() {
+  responseCache.clear();
+}
+
+export async function fetchOpen5eJson<T>(
+  input: string | URL,
+  {
+    fetchFn = fetch,
+    now = Date.now,
+    ttlMs = OPEN5E_RESPONSE_CACHE_TTL_MS,
+  }: FetchOpen5eJsonOptions = {}
+) {
+  const url = input.toString();
+  const cached = responseCache.get(url) as CacheEntry<T> | undefined;
+
+  if (cached && cached.expiresAt > now()) {
+    return cached.promise;
+  }
+
+  const promise = fetchOpen5eJsonWithoutCache<T>(url, fetchFn);
+  responseCache.set(url, {
+    expiresAt: now() + ttlMs,
+    promise,
+  });
+
+  try {
+    return await promise;
+  } catch (error) {
+    if (responseCache.get(url)?.promise === promise) {
+      responseCache.delete(url);
+    }
+
+    throw error;
+  }
+}
+
+export async function fetchOpen5eList<TSource, TResult>({
+  initialUrl,
+  mapResult,
+  maxPages = DEFAULT_MAX_OPEN5E_PAGES,
+  fetchFn,
+  now,
+  ttlMs,
+}: FetchOpen5eListOptions<TSource, TResult>) {
+  const firstUrl = withListLimit(initialUrl);
+  const firstPage = await fetchOpen5eJson<Open5eListResponse<TSource>>(firstUrl, {
+    fetchFn,
+    now,
+    ttlMs,
+  });
+
+  if (hasUsableCount(firstPage.count)) {
+    const pages = await fetchCountedPages({
+      firstPage,
+      firstUrl,
+      fetchFn,
+      maxPages,
+      now,
+      ttlMs,
+    });
+
+    return pages.flatMap((page) => page.results.map(mapResult));
+  }
+
+  const pages = await fetchLinkedPages({
+    firstPage,
+    fetchFn,
+    maxPages,
+    now,
+    ttlMs,
+  });
+
+  return pages.flatMap((page) => page.results.map(mapResult));
+}
+
+async function fetchOpen5eJsonWithoutCache<T>(url: string, fetchFn: typeof fetch) {
+  const response = await fetchFn(url, {
+    next: { revalidate: OPEN5E_REVALIDATE_SECONDS },
+  } as RequestInit);
+
+  if (!response.ok) {
+    throw new Open5eFetchError(response.status, `Open5e request failed: ${url}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function fetchCountedPages<T>({
+  firstPage,
+  firstUrl,
+  fetchFn,
+  maxPages,
+  now,
+  ttlMs,
+}: {
+  firstPage: Open5eListResponse<T>;
+  firstUrl: URL;
+  fetchFn?: typeof fetch;
+  maxPages: number;
+  now?: () => number;
+  ttlMs?: number;
+}) {
+  const limit = getListLimit(firstUrl);
+  const pageCount = Math.min(Math.ceil((firstPage.count ?? 0) / limit), maxPages);
+  const pagePromises = [];
+
+  for (let pageIndex = 1; pageIndex < pageCount; pageIndex += 1) {
+    const pageUrl = new URL(firstUrl);
+    pageUrl.searchParams.set("offset", String(pageIndex * limit));
+    pagePromises.push(
+      fetchOpen5eJson<Open5eListResponse<T>>(pageUrl, {
+        fetchFn,
+        now,
+        ttlMs,
+      })
+    );
+  }
+
+  return [firstPage, ...(await Promise.all(pagePromises))];
+}
+
+async function fetchLinkedPages<T>({
+  firstPage,
+  fetchFn,
+  maxPages,
+  now,
+  ttlMs,
+}: {
+  firstPage: Open5eListResponse<T>;
+  fetchFn?: typeof fetch;
+  maxPages: number;
+  now?: () => number;
+  ttlMs?: number;
+}) {
+  const pages = [firstPage];
+  let nextUrl = firstPage.next;
+
+  while (nextUrl && pages.length < maxPages) {
+    const page = await fetchOpen5eJson<Open5eListResponse<T>>(nextUrl, {
+      fetchFn,
+      now,
+      ttlMs,
+    });
+    pages.push(page);
+    nextUrl = page.next;
+  }
+
+  return pages;
+}
+
+function withListLimit(url: URL) {
+  const nextUrl = new URL(url);
+
+  if (!nextUrl.searchParams.has("limit")) {
+    nextUrl.searchParams.set("limit", String(OPEN5E_LIST_LIMIT));
+  }
+
+  return nextUrl;
+}
+
+function getListLimit(url: URL) {
+  const limit = Number(url.searchParams.get("limit") ?? OPEN5E_LIST_LIMIT);
+  return Number.isFinite(limit) && limit > 0 ? limit : OPEN5E_LIST_LIMIT;
+}
+
+function hasUsableCount(count: number | undefined): count is number {
+  return typeof count === "number" && Number.isFinite(count) && count > 0;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared Open5e fetch helper that caches parsed JSON responses, dedupes concurrent requests, and fetches counted list pages in parallel.
- Route creature, spell, and item list/detail API handlers through the helper and return public cache headers.
- Increase React Query cache retention for reference data and avoid window-focus refetches.

## Testing
- `node --test "lib/open5e/cache.test.ts"`
- `node --test "lib/bestiary/open5e.test.ts" "lib/spells/open5e.test.ts" "lib/items/open5e.test.ts" "lib/open5e/cache.test.ts"`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `curl -sS -D /tmp/open5e_headers.txt -o /tmp/open5e_body.json -w 'status=%{http_code} time_total=%{time_total} size=%{size_download}\n' 'http://localhost:3000/api/open5e/spells?search=acid'`
- `curl -sS -o /tmp/open5e_body_second.json -w 'status=%{http_code} time_total=%{time_total} size=%{size_download}\n' 'http://localhost:3000/api/open5e/spells?search=acid'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6da83c4-2915-4ae5-bde6-1f3614488cc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6da83c4-2915-4ae5-bde6-1f3614488cc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

